### PR TITLE
ML-359: Add file type check for input image

### DIFF
--- a/nodes/platform_io.py
+++ b/nodes/platform_io.py
@@ -7,6 +7,7 @@ import torch
 from signature_core.connectors.google_connector import GoogleConnector
 from signature_core.functional.transform import cutout
 from signature_core.img.tensor_image import TensorImage
+from signature_core.img.utils import is_allowed_file_type
 from uuid_extensions import uuid7str
 
 from .categories import PLATFORM_IO_CAT
@@ -111,6 +112,9 @@ class InputImage:
         def load_image(url_or_base64: str) -> TensorImage:
             if not url_or_base64:
                 raise ValueError("Empty input string")
+
+            if not is_allowed_file_type(url_or_base64):
+                raise ValueError("File does not contain an image format that we support.")
 
             if url_or_base64.startswith("http"):
                 return TensorImage.from_web(url_or_base64)


### PR DESCRIPTION
[JIRA Issue](https://signature-ai.atlassian.net/browse/ML-359)

## Description
This PR uses the file type check from the parallel PR in signature-core. We still need to see how we can send a meaningful error message to the front-end when a user runs a workflow on the platform.

I tested with the following images, the first one is broken:

https://signature-eks-outputs-production.s3.eu-west-1.amazonaws.com/public/inputs/prod/301_1736955923392_0194279c-c1f1-7bf2-b68f-a1ade64ea022.png

https://signatureasset.s3.eu-west-1.amazonaws.com/signature-default/BackgroundRem.jpg

https://signature-eks-outputs-production.s3.eu-west-1.amazonaws.com/public/inputs/prod/289_1736955910047_0194279c-c1f1-7bf2-b68f-a1ade64ea022.png

https://www.gstatic.com/webp/gallery/1.webp