### PR TITLE
ML-384: Add convenience nodes for iterations

### DIFF
--- a/nodes/neurochain/clearml/report_scores.py
+++ b/nodes/neurochain/clearml/report_scores.py
@@ -1,0 +1,47 @@
+from typing import Any, Optional
+
+import pandas as pd
+from clearml import Task
+
+from ...categories import CLEARML_CAT
+from ...utils import any_type
+
+
+class ReportScore:
+    """Reports scores to ClearML."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "task": ("CLEARML_TASK", {}),
+                "score": ("FLOAT",),
+                "name": ("STRING",),
+            },
+            "optional": {
+                "data": (any_type,),
+            },
+        }
+
+    RETURN_TYPES = ("CLEARML_TASK",)
+    RETURN_NAMES = ("clearml_task",)
+    FUNCTION = "process"
+    CATEGORY = CLEARML_CAT
+    OUTPUT_NODE = True
+
+    def process(self, **kwargs):
+        task: Optional[Task] = kwargs.get("task")
+        score: Optional[float] = kwargs.get("score")
+        name: Optional[str] = kwargs.get("name")
+        data: Optional[Any] = kwargs.get("data")
+
+        if task is None or score is None or name is None:
+            raise ValueError("Task, score, and name are required")
+
+        task.get_logger().report_single_value(name, score)
+
+        if data is not None:
+            df = pd.DataFrame(data)
+            task.register_artifact("data", df)
+
+        return (task,)

--- a/nodes/neurochain/clearml/start_task.py
+++ b/nodes/neurochain/clearml/start_task.py
@@ -20,6 +20,10 @@ class StartClearmlTask:
     OUTPUT_NODE = True
 
     def process(self, project_name: str, task_name: str):
-        task = Task.init(project_name=project_name, task_name=task_name)
-        task.get_logger().set_default_upload_destination("s3://signature-ml-models-development/clearml/images/")
+        task = Task.init(
+            project_name=project_name,
+            task_name=task_name,
+            auto_connect_streams=False,
+        )
+        task.get_logger().set_default_upload_destination("s3://signature-clearml/images/")
         return (task,)

--- a/nodes/neurochain/math/average.py
+++ b/nodes/neurochain/math/average.py
@@ -1,0 +1,20 @@
+from ...categories import MATH_CAT
+
+
+class ListAverage:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {"list": ("LIST",)},
+        }
+
+    RETURN_TYPES = ("FLOAT",)
+    RETURN_NAMES = ("average",)
+    FUNCTION = "process"
+    CATEGORY = MATH_CAT
+    OUTPUT_NODE = True
+
+    def process(self, list: list):
+        if not all(isinstance(item, (int, float)) for item in list):
+            raise ValueError("List contains non-numeric items")
+        return (sum(list) / len(list),)

--- a/nodes/utils.py
+++ b/nodes/utils.py
@@ -682,3 +682,50 @@ class Dict2Latent:
         latent = {"samples": tensor_data}
 
         return (latent,)
+
+
+class InputListToList:
+    """Converts a list input to a list as as single output.
+
+    A utility node that takes an input list and returns a single list containing all the inputs.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {"list": (any_type,)},
+        }
+
+    RETURN_TYPES = ("LIST",)
+    RETURN_NAMES = ("list",)
+    FUNCTION = "execute"
+    CATEGORY = UTILS_CAT
+    OUTPUT_NODE = True
+    INPUT_IS_LIST = True
+    CLASS_ID = "input_list_to_list"
+
+    def execute(self, **kwargs):
+        return (kwargs.get("list"),)
+
+
+class ListToOutputList:
+    """Converts a list input to a list as a single output.
+
+    A utility node that takes a list and returns an output list for iterations.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {"list": ("LIST",)},
+        }
+
+    RETURN_TYPES = (any_type,)
+    RETURN_NAMES = ("ANY",)
+    FUNCTION = "execute"
+    CATEGORY = UTILS_CAT
+    OUTPUT_IS_LIST = (True,)
+    CLASS_ID = "list_to_output_list"
+
+    def execute(self, **kwargs):
+        return (kwargs.get("list"),)


### PR DESCRIPTION
[JIRA Issue](https://signature-ai.atlassian.net/browse/ML-384)

## Description
This PR contains new nodes and node updates that I implemented when testing evaluations in ComfyUI (see Jira issue description for an example workflow). Specifically, we want to iterate over lists and collect outputs in a list again. I also needed some update of the ClearML nodes to report scores and data.

If we don't want to merge everything I can still select the parts that seem useful, let me know.

Example workflow: [Benchmark.json](https://github.com/user-attachments/files/18504070/Benchmark.json)

<img width="1883" alt="Screenshot 2025-01-22 at 10 23 07" src="https://github.com/user-attachments/assets/fddb2149-cd2b-4853-84df-e1d83d22690c" />