### PR TITLE
ML-396: Add node run a list of evaluations for a list of agents

### DIFF
--- a/nodes/neurochain/agents/agent.py
+++ b/nodes/neurochain/agents/agent.py
@@ -17,9 +17,9 @@ class Agent:
         return {
             "required": {
                 "llm": ("BaseLLM", {}),
-                "prompt": ("STRING", {"multiline": True}),
             },
             "optional": {
+                "prompt": ("STRING", {"multiline": True}),
                 "tools": ("LIST,AGENT_TOOL", {}),
                 "images": ("LIST,IMAGE", {}),
                 "memory": ("BaseMemory", {}),
@@ -45,7 +45,7 @@ class Agent:
     def process(
         self,
         llm: BaseLLM,
-        prompt: str,
+        prompt: Optional[str] = None,
         tools: Optional[list[BaseAgentTool] | BaseAgentTool] = None,
         images: Optional[list[torch.Tensor] | torch.Tensor] = None,
         memory: Optional[BaseMemory] = None,
@@ -81,7 +81,10 @@ class Agent:
             json_schema=json_schema,
             validators=validators,
         )
-        response = agent.execute(prompt, images=base64_images, conversation_id=str(self.conversation_id))
+
+        response = None
+        if prompt is not None and prompt.strip() != "":
+            response = agent.execute(prompt, images=base64_images, conversation_id=str(self.conversation_id))
         return (
             response,
             agent,

--- a/nodes/neurochain/evaluation/agent_evaluation.py
+++ b/nodes/neurochain/evaluation/agent_evaluation.py
@@ -1,0 +1,80 @@
+from neurochain.agents.agent import Agent
+from neurochain.evaluation.agent_evaluation import (
+    AgentEvaluation as AgentEvaluationNeurochain,
+)
+from neurochain.evaluation.entities import BaseEvaluation
+
+from ...categories import EVALUATION_CAT
+
+
+class AgentEvaluation:
+    """
+    Evaluate a list of agents with a list of evaluators. You need to send a list of prompts and expected outputs.
+    Optionally, the results can be reported to ClearML with a project name and task name. The node will return a list of
+    scores and a summary of the scores.
+
+    Args:
+        agents (list[Agent]): The list of agents to evaluate.
+        evaluators (list[BaseEvaluation]): The list of evaluators to use.
+        prompts (list[str]): The list of prompts to use for the agents.
+        expected_output (list[str]): The list of expected outputs.
+        report_to_clearml (bool): Whether to report the results to ClearML.
+        project_name (str): The name of the project to report to ClearML.
+        task_name (str): The name of the task to report to ClearML.
+
+    Returns:
+        tuple: Contains two elements:
+            scores (list[dict]): The list of scores.
+            scores_summary (dict): The summary of the scores, a row for each agent and a column for each evaluator with
+                the average score in the cells.
+
+    Raises:
+        ValueError: If the agents, evaluators, prompts, or expected output lists are empty.
+        ValueError: If the prompts and expected output lists have different lengths.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "agents": ("LIST", {}),
+                "evaluators": ("LIST", {}),
+                "prompts": ("LIST", {}),
+                "expected_output": ("LIST", {}),
+                "report_to_clearml": ("BOOLEAN", {"default": False}),
+                "project_name": ("STRING", {"default": "Agent Evaluation"}),
+                "task_name": ("STRING", {"default": "Agent Evaluation Task"}),
+            }
+        }
+
+    RETURN_TYPES = ("LIST", "DICT")
+    RETURN_NAMES = ("scores", "scores_summary")
+    FUNCTION = "process"
+    CATEGORY = EVALUATION_CAT
+    OUTPUT_NODE = True
+
+    def process(
+        self,
+        agents: list[Agent],
+        evaluators: list[BaseEvaluation],
+        prompts: list[str],
+        expected_output: list[str],
+        report_to_clearml: bool,
+        project_name: str,
+        task_name: str,
+    ):
+        if agents is None or len(agents) == 0:
+            raise ValueError("Agents list cannot be empty")
+        if evaluators is None or len(evaluators) == 0:
+            raise ValueError("Evaluators list cannot be empty")
+        if prompts is None or len(prompts) == 0:
+            raise ValueError("Prompts list cannot be empty")
+        if expected_output is None or len(expected_output) == 0:
+            raise ValueError("Expected output list cannot be empty")
+        if len(prompts) != len(expected_output):
+            raise ValueError("Prompts and expected output lists must have the same length")
+
+        agent_evaluation = AgentEvaluationNeurochain(agents, evaluators, project_name, task_name)
+        scores = agent_evaluation.evaluate(prompts, expected_output, report_to_clearml)
+        scores_summary = agent_evaluation.scores_summary(scores)
+        return (scores, scores_summary)

--- a/nodes/neurochain/evaluation/bias_evaluation.py
+++ b/nodes/neurochain/evaluation/bias_evaluation.py
@@ -6,20 +6,13 @@ from ...categories import EVALUATION_CAT
 class BiasEvaluation:
     @classmethod
     def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "input": ("STRING", {}),
-                "output": ("STRING", {}),
-            }
-        }
+        return {}
 
-    RETURN_TYPES = ("FLOAT", "STRING")
-    RETURN_NAMES = ("score", "reason")
+    RETURN_TYPES = ("EVALUATOR",)
     FUNCTION = "process"
     CATEGORY = EVALUATION_CAT
     OUTPUT_NODE = True
 
-    def process(self, input: str, output: str):
+    def process(self):
         evaluator = Bias()
-        evaluation_result = evaluator.evaluate(input, output)
-        return (evaluation_result.score, evaluation_result.reason)
+        return (evaluator,)

--- a/nodes/neurochain/evaluation/geval_evaluation.py
+++ b/nodes/neurochain/evaluation/geval_evaluation.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from neurochain.evaluation.geval import Geval
 
 from ...categories import EVALUATION_CAT
@@ -15,10 +17,6 @@ class GevalEvaluation:
     @classmethod
     def INPUT_TYPES(cls):
         return {
-            "required": {
-                "input": ("STRING", {}),
-                "output": ("STRING", {}),
-            },
             "optional": {
                 "criteria": ("STRING", {"default": ""}),
                 "evaluation_steps": (
@@ -28,18 +26,15 @@ class GevalEvaluation:
             },
         }
 
-    RETURN_TYPES = ("FLOAT", "STRING")
-    RETURN_NAMES = ("score", "reason")
+    RETURN_TYPES = ("EVALUATOR",)
     FUNCTION = "process"
     CATEGORY = EVALUATION_CAT
     OUTPUT_NODE = True
 
-    def process(self, input: str, output: str, evaluation_steps: str, criteria: str):
-        neurochain_criteria = criteria.strip()
+    def process(self, evaluation_steps: Optional[str], criteria: Optional[str]):
+        neurochain_criteria = criteria.strip() if criteria else None
         neurochain_evaluation_steps = None
-        if neurochain_criteria == "":
-            neurochain_criteria = None
-            neurochain_evaluation_steps = evaluation_steps.split("\n")
+        if neurochain_criteria is None or neurochain_criteria == "":
+            neurochain_evaluation_steps = evaluation_steps.split("\n") if evaluation_steps else None
         evaluator = Geval(neurochain_criteria, neurochain_evaluation_steps)
-        evaluation_result = evaluator.evaluate(input, output)
-        return (evaluation_result.score, evaluation_result.reason)
+        return (evaluator,)

--- a/nodes/neurochain/evaluation/json_correctness_evaluation.py
+++ b/nodes/neurochain/evaluation/json_correctness_evaluation.py
@@ -17,22 +17,18 @@ class JsonCorrectnessEvaluation:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "input": ("STRING", {}),
                 "json_schema": (
                     "STRING",
                     {"multiline": True, "default": DEFAULT_JSON_SCHEMA},
                 ),
-                "output": ("STRING", {}),
             }
         }
 
-    RETURN_TYPES = ("FLOAT", "STRING")
-    RETURN_NAMES = ("score", "reason")
+    RETURN_TYPES = ("EVALUATOR",)
     FUNCTION = "process"
     CATEGORY = EVALUATION_CAT
     OUTPUT_NODE = True
 
-    def process(self, input: str, json_schema: str, output: str):
+    def process(self, json_schema: str):
         evaluator = JsonCorrectness(json_schema)
-        evaluation_result = evaluator.evaluate(input, output)
-        return (evaluation_result.score, evaluation_result.reason)
+        return (evaluator,)

--- a/nodes/neurochain/evaluation/prompt_alignment_evaluation.py
+++ b/nodes/neurochain/evaluation/prompt_alignment_evaluation.py
@@ -8,25 +8,21 @@ class PromptAlignmentEvaluation:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "input": ("STRING", {}),
                 "prompt_instructions": (
                     "STRING",
                     {"multiline": True, "default": "Output a maximum of 50 words"},
                 ),
-                "output": ("STRING", {}),
             }
         }
 
-    RETURN_TYPES = ("FLOAT", "STRING")
-    RETURN_NAMES = ("score", "reason")
+    RETURN_TYPES = ("EVALUATOR",)
     FUNCTION = "process"
     CATEGORY = EVALUATION_CAT
     OUTPUT_NODE = True
 
-    def process(self, input: str, prompt_instructions: str, output: str):
+    def process(self, prompt_instructions: str):
         prompt_instructions_neurochain = [
             instruction.strip() for instruction in prompt_instructions.split("\n") if instruction.strip()
         ]
         evaluator = PromptAlignment(prompt_instructions_neurochain)
-        evaluation_result = evaluator.evaluate(input, output)
-        return (evaluation_result.score, evaluation_result.reason)
+        return (evaluator,)

--- a/nodes/neurochain/evaluation/summarization_evaluation.py
+++ b/nodes/neurochain/evaluation/summarization_evaluation.py
@@ -6,20 +6,13 @@ from ...categories import EVALUATION_CAT
 class SummarizationEvaluation:
     @classmethod
     def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "input": ("STRING", {}),
-                "output": ("STRING", {}),
-            }
-        }
+        return {}
 
-    RETURN_TYPES = ("FLOAT", "STRING")
-    RETURN_NAMES = ("score", "reason")
+    RETURN_TYPES = ("EVALUATOR",)
     FUNCTION = "process"
     CATEGORY = EVALUATION_CAT
     OUTPUT_NODE = True
 
-    def process(self, input: str, output: str):
+    def process(self):
         evaluator = Summarization()
-        evaluation_result = evaluator.evaluate(input, output)
-        return (evaluation_result.score, evaluation_result.reason)
+        return (evaluator,)

--- a/nodes/neurochain/evaluation/toxicity_evaluation.py
+++ b/nodes/neurochain/evaluation/toxicity_evaluation.py
@@ -6,20 +6,13 @@ from ...categories import EVALUATION_CAT
 class ToxicityEvaluation:
     @classmethod
     def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "input": ("STRING", {}),
-                "output": ("STRING", {}),
-            }
-        }
+        return {}
 
-    RETURN_TYPES = ("FLOAT", "STRING")
-    RETURN_NAMES = ("score", "reason")
+    RETURN_TYPES = ("EVALUATOR",)
     FUNCTION = "process"
     CATEGORY = EVALUATION_CAT
     OUTPUT_NODE = True
 
-    def process(self, input: str, output: str):
+    def process(self):
         evaluator = Toxicity()
-        evaluation_result = evaluator.evaluate(input, output)
-        return (evaluation_result.score, evaluation_result.reason)
+        return (evaluator,)

--- a/nodes/neurochain/neurochain_utils/lines_to_string_list.py
+++ b/nodes/neurochain/neurochain_utils/lines_to_string_list.py
@@ -1,0 +1,19 @@
+from ...categories import NEUROCHAIN_UTILS_CAT
+
+
+class LinesToStringList:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "lines": ("STRING", {"multiline": True}),
+            }
+        }
+
+    RETURN_TYPES = ("LIST",)
+    FUNCTION = "process"
+    CATEGORY = NEUROCHAIN_UTILS_CAT
+    OUTPUT_NODE = True
+
+    def process(self, lines: str):
+        return ([line for line in lines.split("\n") if line.strip()],)


### PR DESCRIPTION
[JIRA Issue](https://signature-ai.atlassian.net/browse/ML-396)

## Description
This PR adds a node to evaluate a list of agents with a list of evaluations. You need to send a list of input prompts of the agent and a list of expected outputs. Optionally you can report the scores to ClearML. 

You will need the parallel PR of neurochain.

An example report in ClearML is here: https://app.ml-platform-clearml.signature.ai/projects/d7f6745177e44092b905ce96f5d164b5/experiments/f4dcc040709545b5843fbdbff56379d0/info-output/metrics/plots?columns=selected&columns=type&columns=name&columns=tags&columns=status&columns=project.name&columns=users&columns=started&columns=last_update&columns=last_iteration&columns=parent.name&order=-last_update&filter=

Example workflow: [AgentEvaluation.json](https://github.com/user-attachments/files/18523755/AgentEvaluation.json)

<img width="1838" alt="Screenshot 2025-01-23 at 15 35 02" src="https://github.com/user-attachments/assets/821f7fa3-469c-4d4d-9bf4-8fb4ce60a20e" />