### PR TITLE
ML-154: Add optional upscale model input to MagicEraser

### DIFF
--- a/nodes/models.py
+++ b/nodes/models.py
@@ -3,11 +3,13 @@ import random
 import comfy.model_management  # type: ignore
 import folder_paths  # type: ignore
 import torch
+from comfy_extras.nodes_upscale_model import ImageUpscaleWithModel
 from signature_core.functional.transform import cutout
 from signature_core.img.tensor_image import TensorImage
 from signature_core.models.lama import Lama
 from signature_core.models.salient_object_detection import SalientObjectDetection
 from signature_core.models.seemore import SeeMore
+from spandrel import ModelLoader
 
 from nodes import SaveImage  # type: ignore
 
@@ -27,6 +29,7 @@ class MagicEraser(SaveImage):
             - "on": Saves preview images
             - "off": No preview images
         filename_prefix (str, optional): Prefix to use for saved output files. Defaults to "Signature".
+        upscale_model (str, optional): Name of the upscale model to use. Defaults to None.
         prompt (str, optional): Text prompt for metadata. Defaults to None.
         extra_pnginfo (dict, optional): Additional metadata to save with output images. Defaults to None.
 
@@ -53,6 +56,9 @@ class MagicEraser(SaveImage):
                 "mask": ("MASK",),
                 "preview": (["on", "off"],),
             },
+            "optional": {
+                "upscale_model": (["None"] + folder_paths.get_filename_list("upscale_models"),),
+            },
             "hidden": {"prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO"},
         }
 
@@ -73,11 +79,35 @@ class MagicEraser(SaveImage):
         if preview not in ["on", "off"]:
             raise ValueError("Preview must be 'on' or 'off'")
 
+        upscale_model = kwargs.get("upscale_model", None)
+        if upscale_model == "None":
+            upscale_model = None
+
+        upscale_fn = None
+        loaded_upscale_model = None
+        device = comfy.model_management.get_torch_device()
+        if upscale_model is not None:
+            upscale_model_path = folder_paths.get_full_path("upscale_models", upscale_model)
+            sd = comfy.utils.load_torch_file(upscale_model_path, safe_load=True)
+            if "module.layers.0.residual_group.blocks.0.norm1.weight" in sd:
+                sd = comfy.utils.state_dict_prefix_replace(sd, {"module.": ""})
+            loaded_upscale_model = ModelLoader().load_from_state_dict(sd)
+            loaded_upscale_model.to(device)
+
+            # TODO: See how we can unify this with the UpscaleImage node, probably it makes sense to extract the code
+            # for the pure upscale into a function or class in signature-core
+            upscaler = ImageUpscaleWithModel
+
+            def upscale_image(image: torch.Tensor) -> torch.Tensor:
+                return upscaler.upscale(upscaler, loaded_upscale_model, image)
+
+            upscale_fn = upscale_image
+
         filename_prefix = kwargs.get("filename_prefix", "Signature")
         prompt = kwargs.get("prompt") or ""
         extra_pnginfo = kwargs.get("extra_pnginfo")
-        device = comfy.model_management.get_torch_device()
-        model = Lama(device)
+
+        model = Lama(device, upscale_fn)
         input_image = TensorImage.from_BWHC(image)
         input_mask = TensorImage.from_BWHC(mask)
         result = TensorImage(model.forward(input_image, input_mask), device=input_mask.device)
@@ -87,8 +117,13 @@ class MagicEraser(SaveImage):
             return (output_images,)
         result = self.save_images(output_images, filename_prefix, prompt, extra_pnginfo)
         result.update({"result": (output_images,)})
+
         model = None
         del model
+        if loaded_upscale_model is not None:
+            loaded_upscale_model = None
+            del loaded_upscale_model
+
         return result
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "pyyaml>=6.0.2",
     "requests>=2.32.3",
+    "spandrel>=0.4.1",
     "tomli-w>=1.1.0",
     "torch>=2.5.1",
     "transformers>=4.46.3",

--- a/uv.lock
+++ b/uv.lock
@@ -235,6 +235,15 @@ wheels = [
 ]
 
 [[package]]
+name = "einops"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/ca/9f5dcb8bead39959454c3912266bedc4c315839cee0e0ca9f4328f4588c1/einops-0.8.0.tar.gz", hash = "sha256:63486517fed345712a8385c100cb279108d9d47e6ae59099b07657e983deae85", size = 58861 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/5a/f0b9ad6c0a9017e62d4735daaeb11ba3b6c009d69a26141b258cd37b5588/einops-0.8.0-py3-none-any.whl", hash = "sha256:9572fb63046264a862693b0a87088af3bdc8c068fde03de63453cbbde245465f", size = 43223 },
+]
+
+[[package]]
 name = "filelock"
 version = "3.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1278,6 +1287,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "requests" },
+    { name = "spandrel" },
     { name = "tomli-w" },
     { name = "torch" },
     { name = "transformers" },
@@ -1299,16 +1309,17 @@ doc = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.35.95" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "huggingface-hub", specifier = "==0.26.2" },
+    { name = "huggingface-hub", specifier = ">=0.26.2" },
     { name = "jq", specifier = ">=1.8.0" },
     { name = "matplotlib", specifier = ">=3.10.0" },
     { name = "opencv-python", specifier = ">=4.10.0.84" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.3" },
+    { name = "spandrel", specifier = ">=0.4.1" },
     { name = "tomli-w", specifier = ">=1.1.0" },
     { name = "torch", specifier = ">=2.5.1" },
-    { name = "transformers", specifier = "==4.46.3" },
+    { name = "transformers", specifier = ">=4.46.3" },
     { name = "uuid7", specifier = ">=0.1.0" },
 ]
 
@@ -1339,6 +1350,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "spandrel"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "einops" },
+    { name = "numpy" },
+    { name = "safetensors" },
+    { name = "torch" },
+    { name = "torchvision" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/e0/048cd03119a9f2b685a79601a52311d5910ff6fd710c01f4ed6769a2892f/spandrel-0.4.1.tar.gz", hash = "sha256:646d9816a942e59d56aab2dc904353952e57dee4b2cb3f59f7ea4dc0fb11a1f2", size = 233544 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/1e/5dce7f0d3eb2aa418bd9cf3e84b2f5d2cf45b1c62488dd139fc93c729cfe/spandrel-0.4.1-py3-none-any.whl", hash = "sha256:49a39aa979769749a42203428355bc4840452854d6334ce0d465af46098dd448", size = 305217 },
 ]
 
 [[package]]
@@ -1457,6 +1485,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/ba/607d013b55b9fd805db2a5c2662ec7551f1910b4eef39653eeaba182c5b2/torch-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:73e58e78f7d220917c5dbfad1a40e09df9929d3b95d25e57d9f8558f84c9a11c", size = 203046841 },
     { url = "https://files.pythonhosted.org/packages/57/6c/bf52ff061da33deb9f94f4121fde7ff3058812cb7d2036c97bc167793bd1/torch-2.5.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:8c712df61101964eb11910a846514011f0b6f5920c55dbf567bff8a34163d5b1", size = 63858109 },
     { url = "https://files.pythonhosted.org/packages/69/72/20cb30f3b39a9face296491a86adb6ff8f1a47a897e4d14667e6cf89d5c3/torch-2.5.1-cp313-cp313-manylinux1_x86_64.whl", hash = "sha256:9b61edf3b4f6e3b0e0adda8b3960266b9009d02b37555971f4d1c8f7a05afed7", size = 906393265 },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/57/4d7ad90be612f5ac6c4bdafcb0ff13e818e14a340a88c8ca00d9ed8c2dad/torchvision-0.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:344b339e15e6bbb59ee0700772616d0afefd209920c762b1604368d8c3458322", size = 1787548 },
+    { url = "https://files.pythonhosted.org/packages/de/e9/e190ecec448d5a2abad8348cf085fcb39962a491e3f40dcb023721e04feb/torchvision-0.20.1-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:86f6523dee420000fe14c3527f6c8e0175139fda7d995b187f54a0b0ebec7eb6", size = 7241222 },
+    { url = "https://files.pythonhosted.org/packages/b1/a3/cbb8177e5e379f0c040b00c6f80f14d323a97e30495d7115d169b101b2f7/torchvision-0.20.1-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:a40d766345927639da322c693934e5f91b1ba2218846c7104b868dea2314ce8e", size = 14267510 },
+    { url = "https://files.pythonhosted.org/packages/69/55/ce836703ff77bb21582c3098d5311f8ddde7eadc7eab04be9561961f4725/torchvision-0.20.1-cp311-cp311-win_amd64.whl", hash = "sha256:5b501d5c04b034d2ecda96a31ed050e383cf8201352e4c9276ca249cbecfded0", size = 1562402 },
+    { url = "https://files.pythonhosted.org/packages/c5/eb/4ba19616378f2bc085999432fded2b7dfdbdccc6dd0fc293203452508100/torchvision-0.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1a31256ff945d64f006bb306813a7c95a531fe16bfb2535c837dd4c104533d7a", size = 1787553 },
+    { url = "https://files.pythonhosted.org/packages/d4/75/00a852275ade58d3dc474530f7a7b6bc999a817148f0eb59d4fde12eb955/torchvision-0.20.1-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:17cd78adddf81dac57d7dccc9277a4d686425b1c55715f308769770cb26cad5c", size = 7240323 },
+    { url = "https://files.pythonhosted.org/packages/af/f0/ca1445406eb12cbeb7a41fc833a1941ede78e7c55621198b83ecd7bcfd0f/torchvision-0.20.1-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:9f853ba4497ac4691815ad41b523ee23cf5ba4f87b1ce869d704052e233ca8b7", size = 14266936 },
+    { url = "https://files.pythonhosted.org/packages/c3/18/00993d420b1d6e88582e51d4bc82c824c99a2e9c045d50eaf9b34fff729a/torchvision-0.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:4a330422c36dbfc946d3a6c1caec3489db07ecdf3675d83369adb2e5a0ca17c4", size = 1562392 },
 ]
 
 [[package]]


### PR DESCRIPTION
[JIRA Issue](https://signature-ai.atlassian.net/browse/ML-154)

## Description
This PR adds an additional input to the MagicEraser for an upscale model. You need the parallel PR of signature-core to test this.

Example Workflow: [MagicEraserUpscale.json](https://github.com/user-attachments/files/18560497/MagicEraserUpscale.json)

<img width="1695" alt="Screenshot 2025-01-27 at 15 06 52" src="https://github.com/user-attachments/assets/da8799da-fbcd-4850-962e-50a56a1432a2" />
