### PR TITLE
ML-410: Update fill template to support nested dict

### DIFF
--- a/nodes/neurochain/neurochain_utils/fill_template.py
+++ b/nodes/neurochain/neurochain_utils/fill_template.py
@@ -20,7 +20,15 @@ class FillTemplate:
     def process(self, data_dict: dict, template: str):
         output = template
 
-        for key, value in data_dict.items():
-            output = output.replace(f"[{key}]", value)
+        def replace_key(template: str, data: dict, parent_path: str = "") -> str:
+            for key, value in data.items():
+                if isinstance(value, dict):
+                    template = replace_key(template, value, parent_path + key + ".")
+                else:
+                    print(f"Replacing {parent_path}{key}")
+                    template = template.replace(f"[{parent_path}{key}]", str(value))
+            return template
+
+        output = replace_key(template, data_dict)
 
         return (output,)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 dev = [
     "bandit>=1.8.0",
     "pre-commit>=4.0.1",
+    "pytest>=8.3.4",
     "ruff>=0.8.6",
 ]
 doc = [
@@ -45,3 +46,8 @@ select = [
 
 [tool.bandit]
 skips = ["B113", "B311"]
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "."
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ select = [
 
 [tool.bandit]
 skips = ["B113", "B311"]
+assert_used.skips = ["*_test.py", "*/test_*.py"]
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/tests/nodes/neurochain/neurochain_utils/test_fill_template.py
+++ b/tests/nodes/neurochain/neurochain_utils/test_fill_template.py
@@ -1,0 +1,61 @@
+from nodes.neurochain.neurochain_utils.fill_template import FillTemplate
+
+
+def test_simple_template_replacement():
+    template = "Hello [name]!"
+    data = {"name": "World"}
+
+    fill = FillTemplate()
+    result = fill.process(data, template)[0]
+
+    assert result == "Hello World!"
+
+
+def test_multiple_replacements():
+    template = "My name is [name] and I am [age] years old"
+    data = {"name": "Alice", "age": "30"}
+
+    fill = FillTemplate()
+    result = fill.process(data, template)[0]
+
+    assert result == "My name is Alice and I am 30 years old"
+
+
+def test_nested_dict_replacement():
+    template = "User: [user.name], Email: [user.contact.email]"
+    data = {"user": {"name": "Bob", "contact": {"email": "bob@example.com"}}}
+
+    fill = FillTemplate()
+    result = fill.process(data, template)[0]
+
+    assert result == "User: Bob, Email: bob@example.com"
+
+
+def test_no_replacements_needed():
+    template = "Plain text without any replacements"
+    data = {"unused": "value"}
+
+    fill = FillTemplate()
+    result = fill.process(data, template)[0]
+
+    assert result == "Plain text without any replacements"
+
+
+def test_empty_dict():
+    template = "Hello [name]!"
+    data = {}
+
+    fill = FillTemplate()
+    result = fill.process(data, template)[0]
+
+    assert result == "Hello [name]!"
+
+
+def test_non_string_values():
+    template = "Number: [number], Boolean: [bool], None: [null]"
+    data = {"number": 42, "bool": True, "null": None}
+
+    fill = FillTemplate()
+    result = fill.process(data, template)[0]
+
+    assert result == "Number: 42, Boolean: True, None: None"

--- a/uv.lock
+++ b/uv.lock
@@ -371,6 +371,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1001,6 +1010,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1045,6 +1063,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8b/1a/3544f4f299a47911c2ab3710f534e52fea62a633c96806995da5d25be4b2/pyparsing-3.2.1.tar.gz", hash = "sha256:61980854fd66de3a90028d679a954d5f2623e83144b5afe5ee86f43d762e5f0a", size = 1067694 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl", hash = "sha256:506ff4f4386c4cec0590ec19e6302d3aedb992fdc02c761e90416f158dacf8e1", size = 107716 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
 ]
 
 [[package]]
@@ -1288,6 +1321,7 @@ dependencies = [
 dev = [
     { name = "bandit" },
     { name = "pre-commit" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 doc = [
@@ -1316,6 +1350,7 @@ requires-dist = [
 dev = [
     { name = "bandit", specifier = ">=1.8.0" },
     { name = "pre-commit", specifier = ">=4.0.1" },
+    { name = "pytest", specifier = ">=8.3.4" },
     { name = "ruff", specifier = ">=0.8.6" },
 ]
 doc = [


### PR DESCRIPTION
[JIRA Issue](https://signature-ai.atlassian.net/browse/ML-410)

## Description
This PR adds support to fill a template with values from a nested dict. The convention to use nested keys in the template is `[key1.subkey1.subsubkey1]` and so on.

I also added tests to see if the code works. I did not find an easy way to run the tests out-of-the-box with pytest as we don't have a `src` folder. You can run the tests when you temporarily rename `__init__.py` to something else and just call `pytest`.

Example workflow: [TemplateFilling.json](https://github.com/user-attachments/files/18561842/TemplateFilling.json)

<img width="1275" alt="Screenshot 2025-01-27 at 17 02 11" src="https://github.com/user-attachments/assets/3c3f69a6-90ec-4f0a-81b9-29a9efacca5e" />