### PR TITLE
ML-414: Update embedding node to support more image/text models

### DIFF
--- a/nodes/neurochain/embeddings/get_embeddings.py
+++ b/nodes/neurochain/embeddings/get_embeddings.py
@@ -1,3 +1,4 @@
+import json
 import os
 from typing import Optional
 
@@ -26,6 +27,20 @@ class GetEmbeddings:
             "optional": {
                 "image": ("IMAGE",),
                 "text": ("STRING",),
+                "sig_additional_metadata": (
+                    "STRING",
+                    {
+                        "default": json.dumps(
+                            {
+                                model["name"]: {
+                                    "showText": model["supports_text"],
+                                    "showImage": model["supports_image"],
+                                }
+                                for model in MODEL_REPOSITORY
+                            }
+                        ),
+                    },
+                ),
             },
         }
 

--- a/nodes/web/get_embeddings.js
+++ b/nodes/web/get_embeddings.js
@@ -1,0 +1,114 @@
+import { app } from "../../../scripts/app.js";
+
+const modelInfo = {
+  resnet50: { showText: false, showImage: true },
+  clip: { showText: true, showImage: true },
+  "mini-lm": { showText: true, showImage: false },
+};
+
+function updateInputsOutputs(node, newVal) {
+  if (modelInfo[newVal].showText) {
+    const slotIndexInputText = node.findInputSlot("text");
+    const widgetText = node.widgets.find((w) => w.name === "text");
+    if (slotIndexInputText < 0 && !widgetText) {
+      node.addWidget("STRING", "text", "");
+    }
+
+    const slotIndexOutputTextEmbeddings = node.findOutputSlot("text_embeddings");
+    if (slotIndexOutputTextEmbeddings < 0) {
+      node.addOutput("text_embeddings", "LIST");
+    }
+  } else {
+    const slotIndexInputText = node.findInputSlot("text");
+    if (slotIndexInputText >= 0) {
+      node.removeInput(slotIndexInputText);
+    }
+    const widgetText = node.widgets.find((w) => w.name === "text");
+    if (widgetText) {
+      node.widgets.splice(node.widgets.indexOf(widgetText), 1);
+    }
+
+    const slotIndexOutputTextEmbeddings = node.findOutputSlot("text_embeddings");
+    if (slotIndexOutputTextEmbeddings >= 0) {
+      node.removeOutput(slotIndexOutputTextEmbeddings);
+    }
+  }
+
+  if (modelInfo[newVal].showImage) {
+    const slotIndexInputImage = node.findInputSlot("image");
+    if (slotIndexInputImage < 0) {
+      node.addInput("image", "IMAGE");
+    }
+
+    const slotIndexOutputImageEmbeddings = node.findOutputSlot("image_embeddings");
+    if (slotIndexOutputImageEmbeddings < 0) {
+      node.addOutput("image_embeddings", "LIST");
+
+      // If there is already a text_embedding output we need to re-create it in the second slot with all its links
+      // I found no other (easier) way to keep any working link between the output and a target node
+      const existingTextOutput = node.outputs.find((o) => o.name === "text_embeddings");
+      if (existingTextOutput) {
+        let storedLinks = [];
+        if (existingTextOutput.links) {
+          storedLinks = existingTextOutput.links.map((l) => node.graph.links[l]);
+        }
+        const slotIndex = node.findOutputSlot("text_embeddings");
+        node.removeOutput(slotIndex);
+        node.addOutput("text_embeddings", "LIST");
+        const newOutput = node.findOutputSlot("text_embeddings");
+        for (const link of storedLinks) {
+          const targetNode = node.graph.nodes.find((n) => n.id === link.target_id);
+          if (targetNode) {
+            node.connect(newOutput, targetNode, link.target_slot);
+          }
+        }
+      }
+    }
+  } else {
+    const slotIndexInputImage = node.findInputSlot("image");
+    if (slotIndexInputImage >= 0) {
+      node.removeInput(slotIndexInputImage);
+    }
+
+    const slotIndexOutputImageEmbeddings = node.findOutputSlot("image_embeddings");
+    if (slotIndexOutputImageEmbeddings >= 0) {
+      node.removeOutput(slotIndexOutputImageEmbeddings);
+    }
+  }
+}
+
+app.registerExtension({
+  name: "signature.GetEmbeddings",
+
+  async nodeCreated(node) {
+    if (node.comfyClass !== "signature_get_embeddings") return;
+
+    for (const w of node.widgets || []) {
+      if (w.name !== "model") continue;
+
+      let widgetValue = w.value;
+      updateInputsOutputs(node, widgetValue);
+      let originalDescriptor = Object.getOwnPropertyDescriptor(w, "value");
+      Object.defineProperty(w, "value", {
+        get() {
+          let valueToReturn =
+            originalDescriptor && originalDescriptor.get ? originalDescriptor.get.call(w) : widgetValue;
+          return valueToReturn;
+        },
+        set(newVal) {
+          const oldVal = widgetValue;
+
+          if (originalDescriptor && originalDescriptor.set) {
+            originalDescriptor.set.call(w, newVal);
+          } else {
+            widgetValue = newVal;
+          }
+
+          if (oldVal !== newVal) {
+            updateInputsOutputs(node, newVal);
+          }
+        },
+      });
+    }
+  },
+});


### PR DESCRIPTION
[JIRA Issue](https://signature-ai.atlassian.net/browse/ML-414)

## Description
This PR updates the Get Embedding node to support two more models besides resnet50: mini-lm-l6 for text embeddings and clip for image/text embeddings. I also updated the node so that it only shows the inputs/outputs that the model supports.

You will need the parallel PR in neurochain to test this.

Example workflow: [Embedding2.json](https://github.com/user-attachments/files/18589425/Embedding2.json)

<img width="940" alt="Screenshot 2025-01-29 at 14 55 04" src="https://github.com/user-attachments/assets/fe78643e-6740-4abe-80cf-e27f99b9a4c2" />