### PR TITLE
feat: add inverted mask output to node

### DIFF
--- a/nodes/mask.py
+++ b/nodes/mask.py
@@ -621,18 +621,20 @@ class MaskGrowWithBlur:
                 for tensor in out
             ]
             blurred = torch.cat(blurred, dim=0)
-            inverted = 1.0 - TensorImage(blurred).get_BWHC()
+            blurred_mask = TensorImage(blurred).get_BWHC()
+            inverted = 1.0 - blurred_mask
 
             return (
-                TensorImage(blurred).get_BWHC(),
+                blurred_mask,
                 inverted,
             )
 
         unblurred = torch.stack(out, dim=0)
-        inverted = 1 - TensorImage(unblurred).get_BWHC()
+        unblurred_mask = TensorImage(unblurred).get_BWHC()
+        inverted = 1 - unblurred_mask
 
         return (
-            TensorImage(unblurred).get_BWHC(),
+            unblurred_mask,
             inverted,
         )
 

--- a/nodes/mask.py
+++ b/nodes/mask.py
@@ -560,7 +560,8 @@ class MaskGrowWithBlur:
         }
 
     CATEGORY = MASK_CAT
-    RETURN_TYPES = ("MASK",)
+    RETURN_TYPES = ("MASK", "MASK")
+    RETURN_NAMES = ("mask", "inverted mask")
     FUNCTION = "expand_mask"
 
     def expand_mask(
@@ -573,7 +574,7 @@ class MaskGrowWithBlur:
         blur_radius: float = 0.0,
         lerp_alpha: float = 1.0,
         decay_factor: float = 1.0,
-    ) -> tuple[torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         mask = TensorImage.from_BWHC(mask)
         alpha = lerp_alpha
         decay = decay_factor
@@ -620,10 +621,20 @@ class MaskGrowWithBlur:
                 for tensor in out
             ]
             blurred = torch.cat(blurred, dim=0)
+            inverted = 1.0 - TensorImage(blurred).get_BWHC()
 
-            return (TensorImage(blurred).get_BWHC(),)
+            return (
+                TensorImage(blurred).get_BWHC(),
+                inverted,
+            )
 
-        return (TensorImage(torch.stack(out, dim=0)).get_BWHC(),)
+        unblurred = torch.stack(out, dim=0)
+        inverted = 1 - TensorImage(unblurred).get_BWHC()
+
+        return (
+            TensorImage(unblurred).get_BWHC(),
+            inverted,
+        )
 
 
 class GetMaskShape:


### PR DESCRIPTION
# Pull Request

[JIRA Issue](https://signature-ai.atlassian.net/browse/ML-183)

## Description
Implement a second output to SIG Mask Grow With Blur node which outputs the inverted mask based on the first output.

<img width="1233" alt="image" src="https://github.com/user-attachments/assets/dd6bc80c-e2c7-4525-a5b2-8e0581ae7f95" />
[worflow.json](https://github.com/user-attachments/files/18655438/Add.InvertMask.to.MaskGrowWithBlur.Workflow.json)

