### PR TITLE
feat: create node to resize images with megapixels

### DIFF
--- a/nodes/image_processing.py
+++ b/nodes/image_processing.py
@@ -1,8 +1,9 @@
+import math
+from typing import Optional
+
 import comfy  # type: ignore
 import folder_paths  # type: ignore
-import math
 import torch
-from typing import Optional
 from comfy import model_management  # type: ignore
 from signature_core.functional.color import rgba_to_rgb
 from signature_core.functional.transform import (
@@ -342,7 +343,6 @@ class ResizeWithMegapixels:
 
     Raises:
         ValueError: If neither image nor mask is provided
-        ValueError: If megapixels is outside valid range
         ValueError: If invalid interpolation method
         RuntimeError: If input tensors have invalid dimensions
 
@@ -429,16 +429,19 @@ class ResizeWithMegapixels:
         interpolation: str = "lanczos",
         antialias: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if not isinstance(image, torch.Tensor) and not isinstance(mask, torch.Tensor):
-            raise ValueError("Either image or mask must be provided")
-
         # Get original dimensions from input tensors if available
         if isinstance(image, torch.Tensor):
-            _, orig_height, orig_width, _ = image.shape
+            if len(image.shape) == 4:
+                _, orig_height, orig_width, _ = image.shape
+            else:
+                orig_height, orig_width, _ = image.shape
         elif isinstance(mask, torch.Tensor):
-            _, orig_height, orig_width, _ = mask.shape
+            if len(mask.shape) == 4:
+                _, orig_height, orig_width, _ = mask.shape
+            else:
+                _, orig_height, orig_width = mask.shape
         else:
-            orig_width = orig_height = 1
+            raise ValueError("Either image or mask must be provided")
 
         target_width, target_height = self.get_dimensions(megapixels, orig_width, orig_height)
 

--- a/nodes/image_processing.py
+++ b/nodes/image_processing.py
@@ -1,5 +1,6 @@
 import comfy  # type: ignore
 import folder_paths  # type: ignore
+import math
 import torch
 from typing import Optional
 from comfy import model_management  # type: ignore
@@ -314,6 +315,146 @@ class Resize:
             output_image,
             output_mask,
         )
+
+
+class ResizeWithMegapixels:
+    """Resizes images and masks to a target megapixel count while preserving aspect ratio.
+
+    A specialized resizing node that targets a specific image size in megapixels rather than
+    exact dimensions. This is useful for batch processing images to a consistent size while
+    maintaining their original proportions and managing memory usage.
+
+    Args:
+        megapixels (float): Target size in megapixels (0.01-100.0)
+        image (torch.Tensor, optional): Input image in BWHC format with values in range [0, 1]
+        mask (torch.Tensor, optional): Input mask in BWHC format with values in range [0, 1]
+        interpolation (str): Resampling method:
+            - "bilinear": Linear interpolation (smooth)
+            - "nearest": Nearest neighbor (sharp)
+            - "bicubic": Cubic interpolation (smoother)
+            - "area": Area averaging (good for downscaling)
+        antialias (bool): Whether to apply antialiasing when downscaling
+
+    Returns:
+        tuple:
+            - image (torch.Tensor): Resized image in BWHC format
+            - mask (torch.Tensor): Resized mask in BWHC format
+
+    Raises:
+        ValueError: If neither image nor mask is provided
+        ValueError: If megapixels is outside valid range
+        ValueError: If invalid interpolation method
+        RuntimeError: If input tensors have invalid dimensions
+
+    Notes:
+        - At least one of image or mask must be provided
+        - Output maintains the same number of channels as input
+        - Aspect ratio is always preserved
+        - Target dimensions are calculated as sqrt(megapixels * 1M * aspect_ratio)
+        - Actual output size may vary slightly due to rounding
+        - Memory usage scales linearly with megapixel count
+        - Antialiasing recommended when downscaling
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):  # type: ignore
+        return {
+            "required": {
+                "megapixels": (
+                    "FLOAT",
+                    {"default": 1.0, "min": 0.01, "max": 100.0, "step": 0.1},
+                ),
+            },
+            "optional": {
+                "image": ("IMAGE", {"default": None}),
+                "mask": ("MASK", {"default": None}),
+                "interpolation": (["bilinear", "nearest", "bicubic", "area"],),
+                "antialias": (
+                    "BOOLEAN",
+                    {"default": True},
+                ),
+            },
+        }
+
+    RETURN_TYPES = (
+        "IMAGE",
+        "MASK",
+    )
+    FUNCTION = "execute"
+    CATEGORY = IMAGE_PROCESSING_CAT
+    DESCRIPTION = """Resize images based on total pixel count (megapixels) while keeping proportions.
+
+    Instead of specifying exact width and height, this node lets you target a specific image size in megapixels. For example:
+    - 1 megapixel = 1000x1000 pixels for a square image
+    - 0.5 megapixels = roughly 707x707 pixels
+    - 2 megapixels = roughly 1414x1414 pixels
+
+    This is useful when you want to:
+    - Resize a batch of images to a consistent size/quality level
+    - Reduce memory usage by targeting a specific megapixel count
+    - Maintain image proportions while hitting a target file size
+    - Prepare images for specific platforms with megapixel limits
+
+    The image will keep its original proportions - a wide image will stay wide, just with the total pixel count you specify."""
+
+    def get_dimensions(self, megapixels: float, original_width: int = 0, original_height: int = 0) -> tuple[int, int]:
+        """Calculate target dimensions based on megapixels while preserving aspect ratio.
+
+        Args:
+            megapixels (float): Target size in megapixels
+            original_width (int): Original image width (optional)
+            original_height (int): Original image height (optional)
+
+        Returns:
+            tuple[int, int]: Target (width, height)
+        """
+        total_pixels = megapixels * 1000000
+
+        if original_width > 0 and original_height > 0:
+            # Preserve aspect ratio if original dimensions are provided
+            aspect_ratio = original_width / original_height
+            height = math.sqrt(total_pixels / aspect_ratio)
+            width = height * aspect_ratio
+        else:
+            # Default to square dimensions if no original dimensions
+            width = height = math.sqrt(total_pixels)
+
+        return (round(width), round(height))
+
+    def execute(
+        self,
+        megapixels: float = 1.0,
+        image: Optional[torch.Tensor] = None,
+        mask: Optional[torch.Tensor] = None,
+        interpolation: str = "bilinear",
+        antialias: bool = True,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if not isinstance(image, torch.Tensor) and not isinstance(mask, torch.Tensor):
+            raise ValueError("Either image or mask must be provided")
+
+        # Get original dimensions from input tensors if available
+        if isinstance(image, torch.Tensor):
+            _, orig_height, orig_width, _ = image.shape
+        elif isinstance(mask, torch.Tensor):
+            _, orig_height, orig_width, _ = mask.shape
+        else:
+            orig_width = orig_height = 1
+
+        target_width, target_height = self.get_dimensions(megapixels, orig_width, orig_height)
+
+        # Create a Resize instance and call its execute method
+        resize_node = Resize()
+        output_image, output_mask = resize_node.execute(
+            image=image,
+            mask=mask,
+            width=target_width,
+            height=target_height,
+            mode="ASPECT",
+            interpolation=interpolation,
+            antialias=antialias,
+        )
+
+        return (output_image, output_mask)
 
 
 class Rotate:

--- a/nodes/image_processing.py
+++ b/nodes/image_processing.py
@@ -430,15 +430,15 @@ class ResizeWithMegapixels:
         antialias: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if isinstance(image, torch.Tensor):
-            image_shape = TensorImage.from_BWHC(image).shape
-            _, orig_height, orig_width, _ = image_shape
+            shape = TensorImage.from_BWHC(image).shape
 
         elif isinstance(mask, torch.Tensor):
-            mask_shape = TensorImage.from_BWHC(mask).shape
-            _, _, orig_height, orig_width = mask_shape
+            shape = TensorImage.from_BWHC(mask).shape
 
         else:
             raise ValueError("Either image or mask must be provided")
+
+        _, _, orig_height, orig_width = shape
 
         target_width, target_height = self.get_dimensions(megapixels, orig_width, orig_height)
 

--- a/nodes/image_processing.py
+++ b/nodes/image_processing.py
@@ -429,17 +429,18 @@ class ResizeWithMegapixels:
         interpolation: str = "lanczos",
         antialias: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        # Get original dimensions from input tensors if available
         if isinstance(image, torch.Tensor):
-            if len(image.shape) == 4:
-                _, orig_height, orig_width, _ = image.shape
-            else:
-                orig_height, orig_width, _ = image.shape
+            image_shape = image.shape
+            if len(image_shape) == 4:  # B,H,W,C
+                _, orig_height, orig_width, _ = image_shape
+            else:  # H,W,C
+                orig_height, orig_width, _ = image_shape
         elif isinstance(mask, torch.Tensor):
-            if len(mask.shape) == 4:
-                _, orig_height, orig_width, _ = mask.shape
-            else:
-                _, orig_height, orig_width = mask.shape
+            mask_shape = mask.shape
+            if len(mask_shape) == 3:  # B,H,W
+                _, orig_height, orig_width = mask_shape
+            else:  # H,W
+                orig_height, orig_width = mask_shape
         else:
             raise ValueError("Either image or mask must be provided")
 

--- a/nodes/image_processing.py
+++ b/nodes/image_processing.py
@@ -273,7 +273,7 @@ class Resize:
                     {"default": 1024, "min": 32, "step": 2, "max": 40960},
                 ),
                 "mode": (["STRETCH", "FIT", "FILL", "ASPECT"],),
-                "interpolation": (["bilinear", "nearest", "bicubic", "area"],),
+                "interpolation": (["lanczos", "bilinear", "nearest", "bicubic", "area"],),
                 "antialias": (
                     "BOOLEAN",
                     {"default": True},
@@ -295,7 +295,7 @@ class Resize:
         width: int = 1024,
         height: int = 1024,
         mode: str = "default",
-        interpolation: str = "nearest",
+        interpolation: str = "lanczos",
         antialias: bool = True,
     ):
         input_image = (
@@ -368,7 +368,7 @@ class ResizeWithMegapixels:
             "optional": {
                 "image": ("IMAGE", {"default": None}),
                 "mask": ("MASK", {"default": None}),
-                "interpolation": (["bilinear", "nearest", "bicubic", "area"],),
+                "interpolation": (["lanczos", "bilinear", "nearest", "bicubic", "area"],),
                 "antialias": (
                     "BOOLEAN",
                     {"default": True},
@@ -426,7 +426,7 @@ class ResizeWithMegapixels:
         megapixels: float = 1.0,
         image: Optional[torch.Tensor] = None,
         mask: Optional[torch.Tensor] = None,
-        interpolation: str = "bilinear",
+        interpolation: str = "lanczos",
         antialias: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if not isinstance(image, torch.Tensor) and not isinstance(mask, torch.Tensor):

--- a/nodes/image_processing.py
+++ b/nodes/image_processing.py
@@ -430,17 +430,13 @@ class ResizeWithMegapixels:
         antialias: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if isinstance(image, torch.Tensor):
-            image_shape = image.shape
-            if len(image_shape) == 4:  # B,H,W,C
-                _, orig_height, orig_width, _ = image_shape
-            else:  # H,W,C
-                orig_height, orig_width, _ = image_shape
+            image_shape = TensorImage.from_BWHC(image).shape
+            _, orig_height, orig_width, _ = image_shape
+
         elif isinstance(mask, torch.Tensor):
-            mask_shape = mask.shape
-            if len(mask_shape) == 3:  # B,H,W
-                _, orig_height, orig_width = mask_shape
-            else:  # H,W
-                orig_height, orig_width = mask_shape
+            mask_shape = TensorImage.from_BWHC(mask).shape
+            _, _, orig_height, orig_width = mask_shape
+
         else:
             raise ValueError("Either image or mask must be provided")
 


### PR DESCRIPTION
# Pull Request

[JIRA Issue](https://signature-ai.atlassian.net/browse/ML-106)

## Description

Create a node that takes a certain megapixels value, calculates the desired Height and Width based on the calculations and resizes the image and/or mask based on the calculations.

## Changes
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/c602c4b2-8498-47fe-9bf8-e7821e7a0861" />
[Resize with megapixels Workflow.json](https://github.com/user-attachments/files/18689267/Resize.with.megapixels.Workflow.json)
