### PR TITLE
Feature/ml 617 implement otsu node

### DIFF
--- a/nodes/otsu.py
+++ b/nodes/otsu.py
@@ -3,10 +3,31 @@ import torch
 from torchvision import ops
 from torchvision.transforms import v2
 
+from .categories import NAME
+
 
 class OTSUNode:
-    # TODO: Add node documentation
-    CATEGORY = "example"  # TODO: Change this to the correct category
+    """A node that performs Otsu's thresholding on an input image.
+
+    This node implements Otsu's method, which automatically determines an optimal threshold
+    value by minimizing intra-class intensity variance. It converts the input image to
+    grayscale and applies binary thresholding using the computed optimal threshold.
+
+    Args:
+        image (torch.Tensor): The input image tensor to threshold.
+                            Expected shape: (B, H, W, C)
+
+    Returns:
+        tuple[float, torch.Tensor]: A tuple containing:
+            - The computed Otsu threshold value
+            - The thresholded binary image as a tensor with shape (B, H, W, C)
+
+    Notes:
+        - The input image is automatically converted to grayscale before thresholding
+        - The output binary image contains values of 0 and 255
+        - The threshold computation is performed using OpenCV's implementation
+    """
+    CATEGORY = f"{NAME}/🧪 Experimental"
 
     @classmethod
     def INPUT_TYPES(s):

--- a/nodes/otsu.py
+++ b/nodes/otsu.py
@@ -1,0 +1,36 @@
+import cv2 as cv
+import torch
+from torchvision import ops
+from torchvision.transforms import v2
+
+
+class OTSUNode:
+    # TODO: Add node documentation
+    CATEGORY = "example"  # TODO: Change this to the correct category
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "image": ("IMAGE",),
+            }
+        }
+
+    RETURN_TYPES = ("FLOAT", "IMAGE")
+    FUNCTION = "execute"
+
+    def execute(self, image: torch.Tensor) -> tuple[float, torch.Tensor]:
+        img_transformed = v2.Compose(
+            [
+                ops.Permute(dims=(0, 3, 2, 1)),
+                v2.Grayscale(),
+                v2.ToDtype(torch.uint8, scale=True),
+            ]
+        )(image)
+        img_np = img_transformed.squeeze().cpu().numpy()
+
+        thresh, out = cv.threshold(img_np, 0, 255, cv.THRESH_BINARY + cv.THRESH_OTSU)
+
+        out_torch = torch.from_numpy(out).to(image.device).unsqueeze(0).unsqueeze(0)
+        out_transformed = v2.Compose([v2.RGB(), ops.Permute(dims=(0, 3, 2, 1))])(out_torch)
+        return (thresh, out_transformed)

--- a/nodes/otsu.py
+++ b/nodes/otsu.py
@@ -3,10 +3,10 @@ import torch
 from torchvision import ops
 from torchvision.transforms import v2
 
-from .categories import NAME
+from .categories import LABS_CAT
 
 
-class OTSUNode:
+class OTSUThreshold:
     """A node that performs Otsu's thresholding on an input image.
 
     This node implements Otsu's method, which automatically determines an optimal threshold
@@ -27,7 +27,8 @@ class OTSUNode:
         - The output binary image contains values of 0 and 255
         - The threshold computation is performed using OpenCV's implementation
     """
-    CATEGORY = f"{NAME}/🧪 Experimental"
+    CLASS_ID = "otsu_threshold"
+    CATEGORY = LABS_CAT
 
     @classmethod
     def INPUT_TYPES(s):


### PR DESCRIPTION
# Pull Request

[JIRA Issue](https://signature-ai.atlassian.net/browse/ML-617)

## Description

This PR will add a node for the OTSU thresholding method.

Current behavior, at time of submission of PR (we should discuss if this is exactly what we want):
- Node is implemented in its own file, `nodes/otsu.py`
- Category is "NAME/Experimental"

Node behavior: 
- input is an image (RGB or Grayscale, float32 or uint8)
- Internally converts to Grayscale uint8
- Outputs threshold (uint8) and thresholded image with values in {0, 255}

## Changes

- Add a file `otsu.py` with a node with OTSU from OpenCV

## How to Trigger Workflows

The version update will be triggered when the PR is merged to main.

Start your commit messages with one of the following keywords to trigger version
updates:

- `patch: `: patch version update (1.0.0 -> 1.0.1)
- `minor: `: Minor version update (1.0.0 -> 1.1.0)
- `major: `: Major version update, breaking changes (1.0.0 -> 2.0.0)
