### PR TITLE
feature/ML-618-Implement-Dino-Node-in-Signature-Nodes

### DIFF
--- a/nodes/neurochain/detectors/dino.py
+++ b/nodes/neurochain/detectors/dino.py
@@ -1,0 +1,31 @@
+from typing import Optional
+from pathlib import Path
+import torch
+from torch import Tensor
+
+import folder_paths
+from ...categories import LABS_CAT
+
+
+class DINOHeatmap:
+    CLASS_ID = "dino_heatmap"
+    CATEGORY = LABS_CAT
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "template": ("IMAGE",),
+            },
+            "optional": {
+                "mask": ("MASK",),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "execute"
+
+    def execute(self, image: Tensor, template: Tensor, mask: Optional[Tensor] = None) -> Tensor:
+        checkpoint_dir = Path(folder_paths.models_dir) / "checkpoints"  # TODO: Decide on a directory for models
+        return (image,)

--- a/nodes/neurochain/detectors/dino.py
+++ b/nodes/neurochain/detectors/dino.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from neurochain.detectors.dino import DINOSimilarity
+from signature_core.img.tensor_image import TensorImage
 from torch import Tensor
 
 from ...categories import LABS_CAT
@@ -53,6 +54,12 @@ class DINOHeatmap:
     FUNCTION = "execute"
 
     def execute(self, image: Tensor, template: Tensor, mask: Optional[Tensor] = None) -> tuple[Tensor,]:
+        image = TensorImage.from_BWHC(image)
+        template = TensorImage.from_BWHC(template)
+        mask = TensorImage.from_BWHC(mask) if mask is not None else None
+
         model = DINOSimilarity()
         output = model.predict(image, template, mask)
+
+        output = TensorImage(output).get_BWHC()
         return (output,)

--- a/nodes/neurochain/detectors/dino.py
+++ b/nodes/neurochain/detectors/dino.py
@@ -1,9 +1,11 @@
-from typing import Optional
 from pathlib import Path
-import torch
+from typing import Optional
+
+from neurochain.detectors import DINOSimilarity
 from torch import Tensor
 
 import folder_paths
+
 from ...categories import LABS_CAT
 
 
@@ -28,4 +30,6 @@ class DINOHeatmap:
 
     def execute(self, image: Tensor, template: Tensor, mask: Optional[Tensor] = None) -> Tensor:
         checkpoint_dir = Path(folder_paths.models_dir) / "checkpoints"  # TODO: Decide on a directory for models
-        return (image,)
+        model = DINOSimilarity(checkpoint_dir=checkpoint_dir)
+        output = model.predict(image, template, mask)
+        return (output,)

--- a/nodes/neurochain/detectors/dino.py
+++ b/nodes/neurochain/detectors/dino.py
@@ -7,6 +7,11 @@ from ...categories import LABS_CAT
 
 
 class DINOHeatmap:
+    """A ComfyUI node that generates similarity heatmaps using DINO Vision Transformer.
+
+    This node takes an input image and a template image, optionally with a mask,
+    and produces a heatmap showing regions similar to the template using DINO embeddings.
+    """
     CLASS_ID = "dino_heatmap"
     CATEGORY = LABS_CAT
 

--- a/nodes/neurochain/detectors/dino.py
+++ b/nodes/neurochain/detectors/dino.py
@@ -14,6 +14,28 @@ class DINOHeatmap:
     """
     CLASS_ID = "dino_heatmap"
     CATEGORY = LABS_CAT
+    DESCRIPTION = """Generates a similarity heatmap between two images using DINO Vision Transformer.
+
+    This node helps you find regions in an image that are similar to a template image. It uses Facebook's DINOv2
+    Vision Transformer model to analyze the images and create a heatmap highlighting matching areas.
+
+    Inputs:
+    - Image: The main image to analyze
+    - Template: The reference image to search for
+    - Mask (optional): A mask to focus the search on specific areas of the template. If provided, mask dimensions (H, W)
+      should be equal to those of the template.
+
+    Output:
+    - A heatmap image where brighter areas indicate stronger similarity to the template
+
+    When a mask is provided, the node will direct attention to specific regions of the template defined by the mask.
+    If no mask is provided, the entire template will be considered for similarity matching.
+
+    This is useful for:
+    - Finding specific objects or patterns in images
+    - Analyzing image composition and recurring elements
+    - Visual pattern matching and comparison
+    - Object localization without traditional object detection"""
 
     @classmethod
     def INPUT_TYPES(cls):

--- a/nodes/neurochain/detectors/dino.py
+++ b/nodes/neurochain/detectors/dino.py
@@ -1,11 +1,10 @@
 from pathlib import Path
 from typing import Optional
 
-from neurochain.detectors import DINOSimilarity
+from neurochain.detectors.dino import DINOSimilarity
 from torch import Tensor
 
-import folder_paths
-
+from ......folder_paths import models_dir
 from ...categories import LABS_CAT
 
 
@@ -28,8 +27,8 @@ class DINOHeatmap:
     RETURN_TYPES = ("IMAGE",)
     FUNCTION = "execute"
 
-    def execute(self, image: Tensor, template: Tensor, mask: Optional[Tensor] = None) -> Tensor:
-        checkpoint_dir = Path(folder_paths.models_dir) / "checkpoints"  # TODO: Decide on a directory for models
+    def execute(self, image: Tensor, template: Tensor, mask: Optional[Tensor] = None) -> tuple[Tensor,]:
+        checkpoint_dir = Path(models_dir) / "checkpoints"  # TODO: Decide on a directory for models
         model = DINOSimilarity(checkpoint_dir=checkpoint_dir)
         output = model.predict(image, template, mask)
         return (output,)

--- a/nodes/neurochain/detectors/dino.py
+++ b/nodes/neurochain/detectors/dino.py
@@ -1,10 +1,8 @@
-from pathlib import Path
 from typing import Optional
 
 from neurochain.detectors.dino import DINOSimilarity
 from torch import Tensor
 
-from ......folder_paths import models_dir
 from ...categories import LABS_CAT
 
 
@@ -28,7 +26,6 @@ class DINOHeatmap:
     FUNCTION = "execute"
 
     def execute(self, image: Tensor, template: Tensor, mask: Optional[Tensor] = None) -> tuple[Tensor,]:
-        checkpoint_dir = Path(models_dir) / "checkpoints"  # TODO: Decide on a directory for models
-        model = DINOSimilarity(checkpoint_dir=checkpoint_dir)
+        model = DINOSimilarity()
         output = model.predict(image, template, mask)
         return (output,)

--- a/nodes/neurochain/detectors/segmentation/u2net.py
+++ b/nodes/neurochain/detectors/segmentation/u2net.py
@@ -22,7 +22,7 @@ class U2NetNode:
     CATEGORY = SEGMENTATION_CAT
 
     def process(self, image: torch.Tensor, clearml_model_id: str):
-        checkpoint_dir = Path(folder_paths.models_dir) / "checkpoints"
+        checkpoint_dir = Path(folder_paths.models_dir) / "checkpoints"  # TODO: Decide on a directory for models
         model = U2Net(model_id=clearml_model_id, checkpoint_dir=checkpoint_dir)
         output = model.predict(image)
         return (output,)

--- a/nodes/otsu.py
+++ b/nodes/otsu.py
@@ -45,7 +45,7 @@ class OTSUThreshold:
     def execute(self, image: torch.Tensor) -> tuple[float, torch.Tensor]:
         img_transformed = v2.Compose(
             [
-                ops.Permute(dims=[0, 3, 2, 1]),
+                ops.Permute(dims=[0, 3, 1, 2]),
                 v2.Grayscale(),
                 v2.ToDtype(torch.uint8, scale=True),
             ]
@@ -55,5 +55,5 @@ class OTSUThreshold:
         thresh, out = cv.threshold(img_np, 0, 255, cv.THRESH_BINARY + cv.THRESH_OTSU)
 
         out_torch = torch.from_numpy(out).to(image.device).unsqueeze(0).unsqueeze(0)
-        out_transformed = v2.Compose([v2.RGB(), ops.Permute(dims=[0, 3, 2, 1])])(out_torch)
+        out_transformed = v2.Compose([v2.RGB(), ops.Permute(dims=[0, 2, 3, 1])])(out_torch)
         return (thresh, out_transformed)


### PR DESCRIPTION
# Pull Request

[JIRA Issue](https://signature-ai.atlassian.net/browse/ML-618)

Mirror PR in neurochain: https://github.com/signatureai/neurochain/pull/86

Added DINO node in signature-nodes and corresponding DINO class in neurochain.

Node functionality
- inputs: image, template, (optional) mask
- output: heatmap
- Computes embeddings for the image (one embedding for each patch) and for the template (entire image if mask is not specified, can also specify a mask and compute one embedding that is the weighted average of the mask)
- Outputs a heatmap which is brighter in the regions of the image that have an embedding similar to that of the template 
