### PR TITLE
feat: add dialog option to manipulate metadata of relevant nodes

### DIFF
--- a/nodes/web/helpers/metadata_editor/main.js
+++ b/nodes/web/helpers/metadata_editor/main.js
@@ -1,0 +1,3 @@
+import { editNodeMetadata, nodeTypesWithMetada } from "./utils.js";
+
+export { editNodeMetadata, nodeTypesWithMetada };

--- a/nodes/web/helpers/metadata_editor/style.js
+++ b/nodes/web/helpers/metadata_editor/style.js
@@ -1,0 +1,42 @@
+const dialog = document.createElement("div");
+dialog.className = "dialog-edit-metadata";
+dialog.style.position = "fixed";
+dialog.style.top = "50%";
+dialog.style.left = "50%";
+dialog.style.transform = "translate(-50%, -50%)";
+dialog.style.backgroundColor = "#333";
+dialog.style.padding = "20px";
+dialog.style.borderRadius = "5px";
+dialog.style.zIndex = "1000";
+dialog.style.minWidth = "500px";
+
+// Create title
+const title = document.createElement("h3");
+title.textContent = "Edit Node Metadata";
+title.style.marginTop = "0";
+
+// Create save and cancel buttons
+const buttonContainer = document.createElement("div");
+buttonContainer.style.marginTop = "20px";
+buttonContainer.style.display = "flex";
+buttonContainer.style.justifyContent = "space-between";
+
+// Create metadata editor
+const metadataContainer = document.createElement("div");
+metadataContainer.style.marginBottom = "20px";
+
+const saveButton = document.createElement("button");
+saveButton.textContent = "Save";
+saveButton.style.backgroundColor = "#4CAF50";
+saveButton.style.color = "white";
+saveButton.style.border = "none";
+saveButton.style.padding = "10px 20px";
+saveButton.style.cursor = "pointer";
+
+const cancelButton = document.createElement("button");
+cancelButton.textContent = "Cancel";
+cancelButton.style.backgroundColor = "#f44336";
+cancelButton.style.color = "white";
+cancelButton.style.border = "none";
+
+export { buttonContainer, cancelButton, dialog, metadataContainer, saveButton, title };

--- a/nodes/web/helpers/metadata_editor/utils.js
+++ b/nodes/web/helpers/metadata_editor/utils.js
@@ -1,0 +1,208 @@
+import { buttonContainer, cancelButton, dialog, metadataContainer, saveButton, title } from "./style.js";
+
+const genericMetadataFields = [
+  {
+    name: "tooltip",
+    type: "string",
+  },
+  {
+    name: "hide_on_null_id",
+    type: "string",
+  },
+  {
+    name: "hide",
+    type: "boolean",
+  },
+];
+
+const metadataDefaultValues = {
+  signature_input_text: {
+    type: "keep one: models or models_object",
+  },
+  signature_input_number: {
+    clamp: "{ min: number, max: number }",
+  },
+};
+const metadataFields = {
+  signature_input_text: [
+    {
+      name: "type",
+      type: "string",
+      default: metadataDefaultValues.signature_input_text.type,
+    },
+    ...genericMetadataFields,
+  ],
+  signature_input_number: [
+    {
+      name: "clamp",
+      type: "string",
+      default: metadataDefaultValues.signature_input_number.clamp,
+    },
+    ...genericMetadataFields,
+  ],
+  signature_input_image: [
+    {
+      name: "mask_id",
+      type: "string",
+    },
+    ...genericMetadataFields,
+  ],
+  signature_output: genericMetadataFields,
+};
+
+const nodeTypesWithMetada = [
+  "signature_input_text",
+  "signature_input_number",
+  "signature_input_image",
+  "signature_output",
+];
+
+const getNodeMetadataWidget = (node) => {
+  const metadata_widget = node.widgets.find((widget) => widget.name === "metadata");
+  const parsed_metadata_widget = JSON.parse(metadata_widget.value);
+  const signature_metadata = node.properties.signature_metadata;
+  return { metadata_widget, parsed_metadata_widget, signature_metadata };
+};
+
+const removeMetadataContainer = () => {
+  const rows = metadataContainer.querySelectorAll(".metadata-row");
+  rows.forEach((row) => row.remove());
+  document.body.removeChild(dialog);
+};
+
+// Function to handle the metadata editing
+const editNodeMetadata = (node) => {
+  // Create a modal dialog for editing metadata
+
+  dialog.appendChild(title);
+
+  let fieldsToShow = [];
+  const nodeType = node.type;
+
+  if (!nodeTypesWithMetada.includes(nodeType)) {
+    return;
+  }
+
+  // If node has no signature_metadata, initialize it
+  if (!node.properties.signature_metadata) {
+    node.properties.signature_metadata = {};
+  }
+
+  // Get the appropriate metadata fields for this node type
+
+  if (metadataFields[nodeType]) {
+    fieldsToShow = metadataFields[nodeType];
+  }
+
+  // Handle the case where fieldsToShow is not an array (like in "signature_input_image")
+  if (!Array.isArray(fieldsToShow)) {
+    fieldsToShow = [fieldsToShow]; // Convert to array with single item
+  }
+
+  const { metadata_widget, parsed_metadata_widget, signature_metadata } = getNodeMetadataWidget(node);
+  // Create inputs for metadata fields
+  fieldsToShow.forEach((field) => {
+    const row = createMetadataFieldRow(
+      field,
+      signature_metadata[field.name] || parsed_metadata_widget[field.name] || field.default || ""
+    );
+
+    metadataContainer.appendChild(row);
+  });
+
+  dialog.appendChild(metadataContainer);
+
+  saveButton.onclick = function () {
+    // Save metadata from inputs
+    const rows = metadataContainer.querySelectorAll(".metadata-row");
+    rows.forEach((row) => {
+      const fieldName = row.dataset.fieldName;
+      const valueInput = row.querySelector(".value-input");
+      const fieldType = row.dataset.fieldType;
+
+      let value = valueInput.value;
+
+      // Convert value based on field type
+      if (fieldType === "boolean") {
+        value = valueInput.checked;
+      } else if (fieldType === "number") {
+        value = parseFloat(value) || 0;
+      }
+
+      // Save or delete metadata both on the metadata_widget and signature_metadata
+      if (
+        value &&
+        (!metadataDefaultValues[nodeType] ||
+          (metadataDefaultValues[nodeType] && !Object.values(metadataDefaultValues[nodeType]).includes(value)))
+      ) {
+        parsed_metadata_widget[fieldName] = value;
+        signature_metadata[fieldName] = value;
+      } else {
+        delete parsed_metadata_widget[fieldName];
+        delete signature_metadata[fieldName];
+      }
+      metadata_widget.value = JSON.stringify(parsed_metadata_widget);
+    });
+    console.log("node:", node);
+
+    removeMetadataContainer();
+  };
+
+  cancelButton.onclick = function () {
+    removeMetadataContainer();
+  };
+
+  buttonContainer.appendChild(cancelButton);
+  buttonContainer.appendChild(saveButton);
+  dialog.appendChild(buttonContainer);
+
+  // Add dialog to body
+  document.body.appendChild(dialog);
+};
+
+// Helper function to create a metadata field row based on field definition
+const createMetadataFieldRow = (field, value) => {
+  const row = document.createElement("div");
+  row.className = "metadata-row";
+  row.style.display = "flex";
+  row.style.marginBottom = "10px";
+  row.style.alignItems = "center";
+  row.dataset.fieldName = field.name;
+  row.dataset.fieldType = field.type;
+
+  // Create label for the field
+  const label = document.createElement("label");
+  label.textContent = field.name;
+  label.style.width = "120px";
+  label.style.marginRight = "10px";
+
+  // Create input based on field type
+  let valueInput;
+
+  if (field.type === "boolean") {
+    valueInput = document.createElement("input");
+    valueInput.type = "checkbox";
+    valueInput.className = "value-input";
+    valueInput.checked = value === true;
+  } else if (field.type === "number") {
+    valueInput = document.createElement("input");
+    valueInput.type = "number";
+    valueInput.className = "value-input";
+    valueInput.value = value || 0;
+    valueInput.style.flex = "1";
+  } else {
+    // Default to string input
+    valueInput = document.createElement("input");
+    valueInput.type = "text";
+    valueInput.className = "value-input";
+    valueInput.value = value || "";
+    valueInput.style.flex = "1";
+  }
+
+  row.appendChild(label);
+  row.appendChild(valueInput);
+
+  return row;
+};
+
+export { editNodeMetadata, nodeTypesWithMetada };

--- a/nodes/web/helpers/metadata_editor/utils.js
+++ b/nodes/web/helpers/metadata_editor/utils.js
@@ -143,7 +143,6 @@ const editNodeMetadata = (node) => {
       }
       metadata_widget.value = JSON.stringify(parsed_metadata_widget);
     });
-    console.log("node:", node);
 
     removeMetadataContainer();
   };

--- a/nodes/web/helpers/workflow/main.js
+++ b/nodes/web/helpers/workflow/main.js
@@ -1,0 +1,29 @@
+import { populateSubmitForm, saveWorkflow, showForm, showWorkflowsList, showWorkflowVersions } from "./form.js";
+import {
+  applyNodeOrderChanges,
+  createNodeItem,
+  initDragAndDrop,
+  processNodeItems,
+  showNodeOrderEditor,
+  updateNodeOrderDisplay,
+  updateOrderDisplay,
+} from "./nodeOrder.js";
+import { deleteWorkflowFromStorage, findMenuList, getLoadingSpinner, getTotalTabs } from "./utils.js";
+export {
+  applyNodeOrderChanges,
+  createNodeItem,
+  deleteWorkflowFromStorage,
+  findMenuList,
+  getLoadingSpinner,
+  getTotalTabs,
+  initDragAndDrop,
+  populateSubmitForm,
+  processNodeItems,
+  saveWorkflow,
+  showForm,
+  showNodeOrderEditor,
+  showWorkflowsList,
+  showWorkflowVersions,
+  updateNodeOrderDisplay,
+  updateOrderDisplay,
+};

--- a/nodes/web/helpers/workflow/nodeOrder.js
+++ b/nodes/web/helpers/workflow/nodeOrder.js
@@ -1,0 +1,526 @@
+import { app } from "../../../../scripts/app.js";
+import { $el } from "../../signature.js";
+import { showMessage } from "../global/main.js";
+import { findMenuList } from "./main.js";
+
+const showNodeOrderEditor = () => {
+  const dropdownMenu = findMenuList();
+  if (dropdownMenu) {
+    dropdownMenu.style.display = "none";
+  }
+  const nodes = app.graph._nodes;
+  if (!nodes || nodes.length === 0) {
+    showMessage("No nodes found in the workflow", "#ff0000");
+    return;
+  }
+
+  // Filter and sort input and output nodes
+  const inputNodes = nodes
+    .filter((node) => node.type.includes("signature_input"))
+    .sort(
+      (a, b) =>
+        (a.properties.signature_order !== undefined ? a.properties.signature_order : 0) -
+        (b.properties.signature_order !== undefined ? b.properties.signature_order : 0)
+    );
+
+  const outputNodes = nodes
+    .filter((node) => node.type.includes("signature_output"))
+    .sort(
+      (a, b) =>
+        (a.properties.signature_order !== undefined ? a.properties.signature_order : 0) -
+        (b.properties.signature_order !== undefined ? b.properties.signature_order : 0)
+    );
+
+  if (inputNodes.length === 0 && outputNodes.length === 0) {
+    showMessage("No input or output nodes found in the workflow", "#ff0000");
+    return;
+  }
+
+  const dialogContent = $el("div", [
+    $el("h2", {
+      style: {
+        textAlign: "center",
+        marginBottom: "20px",
+        color: "#ffffff",
+      },
+      textContent: "Node Order Editor",
+    }),
+    $el("p", {
+      style: {
+        textAlign: "center",
+        marginBottom: "20px",
+        color: "#cccccc",
+      },
+      textContent: "Drag nodes to change their display order on the platform",
+    }),
+    $el("div", {
+      style: {
+        display: "flex",
+        justifyContent: "space-between",
+        gap: "20px",
+        width: "90vw",
+        maxWidth: "1000px",
+        margin: "0 auto",
+      },
+      $: (container) => {
+        // Create the input nodes column
+        const inputColumn = $el(
+          "div",
+          {
+            style: {
+              flex: "1",
+              maxWidth: "calc(50% - 10px)",
+            },
+          },
+          [
+            $el("h3", {
+              style: {
+                textAlign: "center",
+                marginBottom: "15px",
+                color: "#4CAF50",
+              },
+              textContent: "Input Nodes",
+            }),
+            $el("div", {
+              id: "input-nodes-container",
+              style: {
+                backgroundColor: "#1e1e1e",
+                border: "1px solid #444",
+                borderRadius: "4px",
+                padding: "10px",
+                maxHeight: "60vh",
+                overflowY: "auto",
+              },
+              $: (inputContainer) => {
+                // Create the sortable list for input nodes
+                const inputList = $el("div", {
+                  id: "sortable-input-list",
+                  style: {
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "8px",
+                  },
+                });
+
+                // Add each input node as a draggable item
+                inputNodes.forEach((node, index) => {
+                  const nodeItem = createNodeItem(node, index, "input");
+                  inputList.appendChild(nodeItem);
+                });
+
+                if (inputNodes.length > 0) {
+                  inputContainer.appendChild(inputList);
+                } else {
+                  inputContainer.appendChild(
+                    $el("p", {
+                      style: {
+                        textAlign: "center",
+                        color: "#cccccc",
+                      },
+                      textContent: "Workflow has no input nodes",
+                    })
+                  );
+                }
+                // Initialize drag and drop functionality
+                setTimeout(() => {
+                  initDragAndDrop(inputList);
+                }, 100);
+              },
+            }),
+          ]
+        );
+
+        // Create the output nodes column
+        const outputColumn = $el(
+          "div",
+          {
+            style: {
+              flex: "1",
+              maxWidth: "calc(50% - 10px)",
+            },
+          },
+          [
+            $el("h3", {
+              style: {
+                textAlign: "center",
+                marginBottom: "15px",
+                color: "#FF5722",
+              },
+              textContent: "Output Nodes",
+            }),
+            $el("div", {
+              id: "output-nodes-container",
+              style: {
+                backgroundColor: "#1e1e1e",
+                border: "1px solid #444",
+                borderRadius: "4px",
+                padding: "10px",
+                maxHeight: "60vh",
+                overflowY: "auto",
+              },
+              $: (outputContainer) => {
+                // Create the sortable list for output nodes
+                const outputList = $el("div", {
+                  id: "sortable-output-list",
+                  style: {
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "8px",
+                  },
+                });
+
+                // Add each output node as a draggable item
+                outputNodes.forEach((node, index) => {
+                  const nodeItem = createNodeItem(node, index, "output");
+                  outputList.appendChild(nodeItem);
+                });
+
+                if (outputNodes.length > 0) {
+                  outputContainer.appendChild(outputList);
+                } else {
+                  outputContainer.appendChild(
+                    $el("p", {
+                      style: {
+                        textAlign: "center",
+                        color: "#cccccc",
+                      },
+                      textContent: "Workflow has no output nodes",
+                    })
+                  );
+                }
+                // Initialize drag and drop functionality
+                setTimeout(() => {
+                  initDragAndDrop(outputList);
+                }, 100);
+              },
+            }),
+          ]
+        );
+
+        container.append(inputColumn, outputColumn);
+      },
+    }),
+    // Apply button
+    $el(
+      "div",
+      {
+        style: {
+          display: "flex",
+          justifyContent: "center",
+          marginTop: "20px",
+        },
+      },
+      [
+        $el("button", {
+          style: {
+            padding: "10px 20px",
+            backgroundColor: "#2D9CDB",
+            color: "white",
+            border: "none",
+            borderRadius: "4px",
+            cursor: "pointer",
+            fontSize: "16px",
+          },
+          textContent: "Apply Order Changes",
+          onclick: () => {
+            applyNodeOrderChanges();
+            app.ui.dialog.close();
+            showMessage("Node order updated successfully!", "#00ff00");
+          },
+        }),
+      ]
+    ),
+  ]);
+
+  app.ui.dialog.show(dialogContent);
+};
+
+const createNodeItem = (node, index, nodeType) => {
+  const bgColor = nodeType === "input" ? "#1a3a1a" : "#3a1a1a";
+  const borderColor = nodeType === "input" ? "#2a5a2a" : "#5a2a2a";
+
+  return $el(
+    "div",
+    {
+      className: `draggable-node-item ${nodeType}-node`,
+      "data-node-id": node.id,
+      "data-original-index": index,
+      "data-original-order": node.properties.order !== undefined ? node.properties.order : "unset",
+      "data-node-type": nodeType,
+      style: {
+        padding: "12px",
+        backgroundColor: bgColor,
+        border: `1px solid ${borderColor}`,
+        borderRadius: "4px",
+        cursor: "grab",
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        userSelect: "none",
+      },
+    },
+    [
+      $el(
+        "div",
+        {
+          style: {
+            display: "flex",
+            alignItems: "center",
+            gap: "10px",
+            flex: "1",
+            overflow: "hidden",
+          },
+        },
+        [
+          // Node type icon or indicator
+          $el("div", {
+            style: {
+              minWidth: "24px",
+              height: "24px",
+              backgroundColor: node.bgcolor || "#666",
+              borderRadius: "4px",
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              color: "#fff",
+              fontWeight: "bold",
+            },
+            textContent: node.type.charAt(0).toUpperCase(),
+          }),
+          // Node title and type
+          $el(
+            "div",
+            {
+              style: {
+                display: "flex",
+                flexDirection: "column",
+                overflow: "hidden",
+                flex: "1",
+              },
+            },
+            [
+              $el("div", {
+                style: {
+                  color: "#ffffff",
+                  fontWeight: "bold",
+                  fontSize: "15px",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                },
+                title: node.title || node.name || `Node ${node.id}`,
+                textContent: node.title || node.name || `Node ${node.id}`,
+              }),
+              $el("div", {
+                style: {
+                  color: "#aaaaaa",
+                  fontSize: "12px",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                },
+                title: `ID: ${node.id} - ${node.widgets.find((widget) => widget.name === "title").value}`,
+                textContent: `ID: ${node.id} - ${node.widgets.find((widget) => widget.name === "title").value}`,
+              }),
+            ]
+          ),
+        ]
+      ),
+      // Order display (relative position within group)
+      $el("div", {
+        className: "node-order-display",
+        style: {
+          color: "#888888",
+          fontSize: "14px",
+          minWidth: "140px",
+          textAlign: "right",
+        },
+        innerHTML: `Position: <span class="original-order">${index + 1}</span> → <span class="new-order">${
+          index + 1
+        }</span>
+                   <div style="font-size: 11px; color: #666;">Global: ${
+                     node.properties.order !== undefined ? node.properties.order : "unset"
+                   }</div>`,
+      }),
+    ]
+  );
+};
+
+const updateOrderDisplay = () => {
+  // Update input nodes
+  const inputList = document.getElementById("sortable-input-list");
+  if (inputList) {
+    const inputItems = inputList.querySelectorAll(".draggable-node-item");
+    inputItems.forEach((item, index) => {
+      updateNodeOrderDisplay(item, index);
+    });
+  }
+
+  // Update output nodes
+  const outputList = document.getElementById("sortable-output-list");
+  if (outputList) {
+    const outputItems = outputList.querySelectorAll(".draggable-node-item");
+    outputItems.forEach((item, index) => {
+      updateNodeOrderDisplay(item, index);
+    });
+  }
+};
+
+const updateNodeOrderDisplay = (item, index) => {
+  const orderDisplay = item.querySelector(".node-order-display");
+  if (orderDisplay) {
+    const originalIndex = parseInt(item["data-original-index"]);
+    const newOrderSpan = orderDisplay.querySelector(".new-order");
+
+    if (newOrderSpan) {
+      newOrderSpan.textContent = index + 1; // Display 1-based position for user friendliness
+    }
+
+    // Highlight changed orders
+    if (originalIndex !== index) {
+      newOrderSpan.style.color = "#4CAF50";
+      newOrderSpan.style.fontWeight = "bold";
+    } else {
+      newOrderSpan.style.color = "#888888";
+      newOrderSpan.style.fontWeight = "normal";
+    }
+  }
+};
+
+const processNodeItems = (items) => {
+  const newItems = items.map((item, index) => {
+    let nodeId = item["data-node-id"] || item.id;
+    if (!nodeId) {
+      console.warn("No node ID found for item:", item);
+      return;
+    }
+
+    const node = app.graph.getNodeById(parseInt(nodeId));
+
+    if (node) {
+      // Store in properties for serialization - this is crucial for saving to workflow.json
+      if (!node.properties) {
+        node.properties = {};
+      }
+      node.properties.signature_order = index;
+    } else {
+      console.warn(`Node with ID ${nodeId} not found in graph`);
+    }
+    return node;
+  });
+
+  return newItems;
+};
+
+const applyNodeOrderChanges = () => {
+  const allNodes = app.graph._nodes;
+  const newOrder = [];
+  const regularNodes = allNodes.filter(
+    (node) => !node.type.includes("signature_input") && !node.type.includes("signature_output")
+  );
+
+  newOrder.push(...regularNodes);
+
+  // Process input nodes - they always come first
+  const inputList = document.getElementById("sortable-input-list");
+  if (inputList) {
+    // Fix: Use querySelectorAll to get all items properly
+    const inputItems = inputList.childNodes;
+    newOrder.push(...inputItems);
+  }
+
+  // Process output nodes - they always come last
+  const outputList = document.getElementById("sortable-output-list");
+  if (outputList) {
+    // Fix: Use querySelectorAll to get all items properly
+    const outputItems = outputList.childNodes;
+    newOrder.push(...outputItems);
+  }
+
+  const newNodesOrder = processNodeItems(newOrder);
+  app.graph._nodes = newNodesOrder;
+
+  app.graph.setDirtyCanvas(true, true);
+
+  app.graph.change();
+};
+
+const initDragAndDrop = (container) => {
+  const items = container.querySelectorAll(".draggable-node-item");
+  let draggedItem = null;
+
+  items.forEach((item) => {
+    // Make item draggable
+    item.setAttribute("draggable", "true");
+
+    // Add drag start event
+    item.addEventListener("dragstart", function (e) {
+      draggedItem = item;
+      setTimeout(() => {
+        item.style.opacity = "0.5";
+      }, 0);
+    });
+
+    // Add drag end event
+    item.addEventListener("dragend", function () {
+      if (draggedItem) {
+        draggedItem.style.opacity = "1";
+        draggedItem = null;
+
+        // Update the order display on all items
+        updateOrderDisplay();
+      }
+    });
+
+    // Add dragover event
+    item.addEventListener("dragover", function (e) {
+      e.preventDefault();
+      if (this !== draggedItem && draggedItem) {
+        const rect = this.getBoundingClientRect();
+        const midpoint = (rect.top + rect.bottom) / 2;
+
+        if (e.clientY < midpoint) {
+          // Insert before
+          if (this.previousElementSibling !== draggedItem) {
+            container.insertBefore(draggedItem, this);
+          }
+        } else {
+          // Insert after
+          if (this.nextElementSibling !== draggedItem) {
+            container.insertBefore(draggedItem, this.nextElementSibling);
+          }
+        }
+      }
+    });
+
+    // Add drop event to ensure proper handling
+    item.addEventListener("drop", function (e) {
+      e.preventDefault();
+      // The actual reordering is handled in dragover
+    });
+  });
+
+  // Add dragover and drop handlers to the container itself
+  container.addEventListener("dragover", function (e) {
+    e.preventDefault();
+  });
+
+  container.addEventListener("drop", function (e) {
+    e.preventDefault();
+    if (draggedItem) {
+      draggedItem.style.opacity = "1";
+      updateOrderDisplay();
+      draggedItem = null;
+    }
+  });
+};
+
+export {
+  applyNodeOrderChanges,
+  createNodeItem,
+  initDragAndDrop,
+  processNodeItems,
+  showNodeOrderEditor,
+  updateNodeOrderDisplay,
+  updateOrderDisplay,
+};

--- a/nodes/web/helpers/workflow/node_order/style.js
+++ b/nodes/web/helpers/workflow/node_order/style.js
@@ -19,16 +19,16 @@ const showNodeOrderEditor = () => {
     .filter((node) => node.type.includes("signature_input"))
     .sort(
       (a, b) =>
-        (a.properties.signature_order !== undefined ? a.properties.signature_order : 0) -
-        (b.properties.signature_order !== undefined ? b.properties.signature_order : 0)
+        (a.properties.signature_metadata.order !== undefined ? a.properties.signature_metadata.order : 0) -
+        (b.properties.signature_metadata.order !== undefined ? b.properties.signature_metadata.order : 0)
     );
 
   const outputNodes = nodes
     .filter((node) => node.type.includes("signature_output"))
     .sort(
       (a, b) =>
-        (a.properties.signature_order !== undefined ? a.properties.signature_order : 0) -
-        (b.properties.signature_order !== undefined ? b.properties.signature_order : 0)
+        (a.properties.signature_metadata.order !== undefined ? a.properties.signature_metadata.order : 0) -
+        (b.properties.signature_metadata.order !== undefined ? b.properties.signature_metadata.order : 0)
     );
 
   if (inputNodes.length === 0 && outputNodes.length === 0) {

--- a/nodes/web/helpers/workflow/node_order/utils.js
+++ b/nodes/web/helpers/workflow/node_order/utils.js
@@ -167,7 +167,7 @@ const processNodeItems = (items) => {
       if (!node.properties) {
         node.properties = {};
       }
-      node.properties.signature_order = index;
+      node.properties.signature_metadata.order = index;
     } else {
       console.warn(`Node with ID ${nodeId} not found in graph`);
     }

--- a/nodes/web/metada_editor.js
+++ b/nodes/web/metada_editor.js
@@ -1,0 +1,37 @@
+import { editNodeMetadata, nodeTypesWithMetada } from "./helpers/metadata_editor/main.js";
+
+// Modify initialization function
+const initMetadataEditor = () => {
+  // Wait for LiteGraph to be fully loaded
+  if (typeof LGraphCanvas === "undefined") {
+    setTimeout(initMetadataEditor, 500);
+    return;
+  }
+
+  // Store original onAdded function if it exists
+  const originalOnAdded = LGraphNode.prototype.onAdded;
+
+  LGraphNode.prototype.onAdded = function () {
+    if (originalOnAdded) {
+      originalOnAdded.call(this);
+    }
+
+    // Add widget only to specified node types
+    if (nodeTypesWithMetada.includes(this.type)) {
+      this.addWidget(
+        "button",
+        "Edit Metadata",
+        null,
+        function (value, widget, node) {
+          editNodeMetadata(node);
+        },
+        { width: 30 }
+      );
+    }
+  };
+
+  console.log("Metadata editor initialized");
+};
+
+// Start initialization
+initMetadataEditor();


### PR DESCRIPTION
# Pull Request

[JIRA Issue](https://signature-ai.atlassian.net/browse/SIGML-676)
[JIRA Issue](https://signature-ai.atlassian.net/browse/SIGML-677)

## Description

Add metadata button to relevant nodes that opens a dialogue box with all the metadata fields and, if applicable, default/placeholders.
Metadata is now saved on the the metadata widget and a `signature_metadata` inside the `properties` key in the node.
Node order is now being saved on the `signature_metadata` object

## Changes

https://github.com/user-attachments/assets/69ca3218-55f0-4594-9075-67b3ea85dbed

[metadata test.json](https://github.com/user-attachments/files/19364202/metadata.test.json)
