### PR TITLE
fix: remove image channels when subtype in input_image is mask

### DIFF
--- a/nodes/core/platform/input_image.py
+++ b/nodes/core/platform/input_image.py
@@ -179,9 +179,10 @@ class InputImage:
             if subtype == "mask":
                 if output.shape[1] == 4:
                     rgb = TensorImage(output[:, :3, :, :])
-                    outputs[i] = rgb_to_grayscale(rgb).get_BWHC()
+                    mask_output = rgb_to_grayscale(rgb).get_BWHC()
                 else:
-                    outputs[i] = output.get_BWHC()
+                    mask_output = output.get_BWHC()
+                outputs[i] = mask_output[:, :, :, 0]
             else:
                 outputs[i] = post_process(output, include_alpha).get_BWHC()
         return (outputs,)


### PR DESCRIPTION
# Pull Request

[JIRA Issue](https://signature-ai.atlassian.net/browse/SIGML-689)

## Description

Output shape of Input image node, when it's ran with subtype `mask`, now doesn't display the channels

Fixes # (SIGML-689)

## Changes

<img width="801" alt="image" src="https://github.com/user-attachments/assets/0f874b9b-038e-460b-9093-61744dc281a6" />

