### PR TITLE
Remove model version in training

### DIFF
--- a/nodes/neurochain/dojo/create_training_run.py
+++ b/nodes/neurochain/dojo/create_training_run.py
@@ -44,7 +44,7 @@ class CreateTrainingRun:
         "STRING",
         "STRING",
     )
-    RETURN_NAMES = ("model_id", "model_version", "user_id", "org_id", "s3_bucket_name")
+    RETURN_NAMES = ("model_id", "user_id", "org_id", "s3_bucket_name")
     FUNCTION = "process"
     CATEGORY = DOJO_CAT
     OUTPUT_NODE = True

--- a/nodes/neurochain/dojo/create_training_run.py
+++ b/nodes/neurochain/dojo/create_training_run.py
@@ -42,7 +42,6 @@ class CreateTrainingRun:
         "STRING",
         "STRING",
         "STRING",
-        "STRING",
     )
     RETURN_NAMES = ("model_id", "user_id", "org_id", "s3_bucket_name")
     FUNCTION = "process"

--- a/nodes/neurochain/dojo/start_training_run.py
+++ b/nodes/neurochain/dojo/start_training_run.py
@@ -9,7 +9,6 @@ class StartTrainingRun:
         return {
             "required": {
                 "model_id": ("STRING", {"default": ""}),
-                "model_version": ("STRING", {"default": ""}),
                 "org_id": (
                     "STRING",
                     {"default": "66310e12f6ce596d498cb975"},
@@ -38,7 +37,6 @@ class StartTrainingRun:
     def process(
         self,
         model_id: str,
-        model_version: str,
         org_id: str,
         user_id: str,
         is_flux: bool,
@@ -50,7 +48,6 @@ class StartTrainingRun:
         if is_flux:
             training_id = StartTrainingRunNeurochain().start_flux_training(
                 model_id,
-                model_version,
                 org_id,
                 user_id,
                 s3_bucket_name,


### PR DESCRIPTION
## Description
In the new training pipeline we do not use the model version anymore. This needs an update of neurochain that is in a parallel PR. In neurochain there are more changes when we call the API, but for ComfyUI the relevant change is the model version.