### PR TITLE
feat: add random min and max crop size input to guided random crop node

### DIFF
--- a/nodes/core/image_processing/guided_random_crop.py
+++ b/nodes/core/image_processing/guided_random_crop.py
@@ -81,14 +81,13 @@ class GuidedRandomCrop:
                 crop_size = random.randint(min_crop_size, max_crop_size)
 
                 # Calculate initial crop boundaries
-                half_w = crop_size // 2
-                half_h = crop_size // 2
+                dimension = crop_size // 2
 
                 # Calculate initial boundaries
-                start_x = x - half_w
-                end_x = x + half_w
-                start_y = y - half_h
-                end_y = y + half_h
+                start_x = x - dimension
+                end_x = x + dimension
+                start_y = y - dimension
+                end_y = y + dimension
 
                 # Shift the box if it goes out of bounds
                 if start_x < 0:


### PR DESCRIPTION
[JIRA Issue](https://signature-ai.atlassian.net/browse/SIGML-696)

## Description

add min and max crop size as input on guided random crop node.
the crop size is now randomised, for each crop, based on the given values

<img width="1360" alt="image" src="https://github.com/user-attachments/assets/fde58b2f-28fa-4f97-a475-9bde807097bc" />
