### PR TITLE
Hotfix release/2.1.4 sigml 697 input boolean node edit metadata option is missing for this type of input

### DIFF
--- a/nodes/web/helpers/metadata_editor/utils.js
+++ b/nodes/web/helpers/metadata_editor/utils.js
@@ -48,9 +48,11 @@ const metadataFields = {
     ...genericMetadataFields,
   ],
   signature_output: genericMetadataFields,
+  signature_input_boolean: genericMetadataFields,
 };
 
 const nodeTypesWithMetada = [
+  "signature_input_boolean",
   "signature_input_text",
   "signature_input_number",
   "signature_input_image",

--- a/nodes/web/helpers/workflow/node_order/style.js
+++ b/nodes/web/helpers/workflow/node_order/style.js
@@ -6,11 +6,12 @@ import { applyNodeOrderChanges, createNodeItem, initDragAndDrop } from "./utils.
 const showNodeOrderEditor = () => {
   const nodes = app.graph._nodes;
   nodes.forEach((node) => {
-    if (!node.properties.signature_metadata) {
-      node.properties.signature_metadata = {};
+    const signature_metadata = node.properties.signature_metadata;
+    if (!signature_metadata) {
+      signature_metadata = {};
     }
-    if (!node.properties.signature_metadata.order) {
-      node.properties.signature_metadata.order = 0;
+    if (!signature_metadata.order) {
+      signature_metadata.order = 0;
     }
   });
   if (!nodes || nodes.length === 0) {

--- a/nodes/web/helpers/workflow/node_order/utils.js
+++ b/nodes/web/helpers/workflow/node_order/utils.js
@@ -10,7 +10,8 @@ const createNodeItem = (node, index, nodeType) => {
       className: `draggable-node-item ${nodeType}-node`,
       "data-node-id": node.id,
       "data-original-index": index,
-      "data-original-order": node.properties.signature_metadata.order !== undefined ? node.properties.signature_metadata.order : "unset",
+      "data-original-order":
+        node.properties.signature_metadata.order !== undefined ? node.properties.signature_metadata.order : "unset",
       "data-node-type": nodeType,
       style: {
         padding: "12px",
@@ -104,7 +105,9 @@ const createNodeItem = (node, index, nodeType) => {
           index + 1
         }</span>
                      <div style="font-size: 11px; color: #666;">Global: ${
-                       node.properties.signature_metadata.order !== undefined ? node.properties.signature_metadata.order : "unset"
+                       node.properties.signature_metadata.order !== undefined
+                         ? node.properties.signature_metadata.order
+                         : "unset"
                      }</div>`,
       }),
     ]
@@ -168,6 +171,23 @@ const processNodeItems = (items) => {
         node.properties = {};
       }
       node.properties.signature_metadata.order = index;
+      // Update metadata widget value
+      if (node.widgets) {
+        const metadataWidget = node.widgets.find((widget) => widget.name === "metadata");
+        if (metadataWidget) {
+          try {
+            const existingMetadata = JSON.parse(metadataWidget.value || "{}");
+            metadataWidget.value = JSON.stringify({ ...existingMetadata, order: index });
+            // If there's a clamp property, make sure it's an object, not a string
+            if (existingMetadata.clamp && typeof existingMetadata.clamp === "string") {
+              existingMetadata.clamp = JSON.parse(existingMetadata.clamp);
+            }
+          } catch (e) {
+            console.error("Parse/update failed:", e);
+            metadataWidget.value = JSON.stringify({ order: index });
+          }
+        }
+      }
     } else {
       console.warn(`Node with ID ${nodeId} not found in graph`);
     }


### PR DESCRIPTION
# Pull Request

[JIRA Issue](https://signature-ai.atlassian.net/browse/SIGML-697)

## Description

Add signature Input Boolean to list of nodes with editable metadata
Add order change on metadata widget as well