### PR TITLE
fix: remove assignment of value to const on node order metadata

### DIFF
--- a/nodes/web/helpers/workflow/node_order/style.js
+++ b/nodes/web/helpers/workflow/node_order/style.js
@@ -6,12 +6,11 @@ import { applyNodeOrderChanges, createNodeItem, initDragAndDrop } from "./utils.
 const showNodeOrderEditor = () => {
   const nodes = app.graph._nodes;
   nodes.forEach((node) => {
-    const signature_metadata = node.properties.signature_metadata;
-    if (!signature_metadata) {
-      signature_metadata = {};
+    if (!node.properties.signature_metadata) {
+      node.properties.signature_metadata = {};
     }
-    if (!signature_metadata.order) {
-      signature_metadata.order = 0;
+    if (!node.properties.signature_metadata.order) {
+      node.properties.signature_metadata.order = 0;
     }
   });
   if (!nodes || nodes.length === 0) {


### PR DESCRIPTION
# Pull Request

[JIRA Issue](https://signature-ai.atlassian.net/browse/SIGML-698)

## Description

Changed code so it doesn't assign a new value to a const in the node order