### PR TITLE
fix: handle images where the shape has 3 indexes

### DIFF
--- a/nodes/core/platform/input_image.py
+++ b/nodes/core/platform/input_image.py
@@ -180,9 +180,9 @@ class InputImage:
                 if output.shape[1] == 4:
                     rgb = TensorImage(output[:, :3, :, :])
                     mask_output = rgb_to_grayscale(rgb).get_BWHC()
+                    outputs[i] = mask_output[:, :, :, 0]
                 else:
-                    mask_output = output.get_BWHC()
-                outputs[i] = mask_output[:, :, :, 0]
+                    outputs[i] = output.get_BWHC()
             else:
                 outputs[i] = post_process(output, include_alpha).get_BWHC()
         return (outputs,)


### PR DESCRIPTION
# Pull Request

[JIRA Issue](https://signature-ai.atlassian.net/browse/SIGML-699)

## Description

get_BWHC function already returns a Tensor with 3 channels if it's a mask so no more logic needed