### PR TITLE
fix: update condition to run model on magic eraser node

### DIFF
--- a/nodes/core/models/magic_eraser.py
+++ b/nodes/core/models/magic_eraser.py
@@ -81,7 +81,6 @@ class MagicEraser(SaveImage):
         loaded_upscale_model = None
         device = comfy.model_management.get_torch_device()
         if upscale_model is not None and upscale_model != "None":
-            print("upscale_model", upscale_model)
             upscale_model_path = folder_paths.get_full_path("upscale_models", upscale_model)
             sd = comfy.utils.load_torch_file(upscale_model_path, safe_load=True)
             if "module.layers.0.residual_group.blocks.0.norm1.weight" in sd:

--- a/nodes/core/models/magic_eraser.py
+++ b/nodes/core/models/magic_eraser.py
@@ -80,7 +80,8 @@ class MagicEraser(SaveImage):
         upscale_fn = None
         loaded_upscale_model = None
         device = comfy.model_management.get_torch_device()
-        if upscale_model is not None:
+        if upscale_model is not None and upscale_model != "None":
+            print("upscale_model", upscale_model)
             upscale_model_path = folder_paths.get_full_path("upscale_models", upscale_model)
             sd = comfy.utils.load_torch_file(upscale_model_path, safe_load=True)
             if "module.layers.0.residual_group.blocks.0.norm1.weight" in sd:


### PR DESCRIPTION
# Pull Request

[JIRA Issue](SIGML-625-magic-eraser-error)

## Description

Update condition to run model on magic eraser. Now it takes into account if the model being passed is also not `"None"`

Fixes # (SIGML-625)

## Changes

![image](https://github.com/user-attachments/assets/2ceda688-d98f-4e9e-af8b-8d28ec3fe1fc)
