### PR TITLE
SIGML-763: Add global setting object with correlation ID

### DIFF
--- a/src/signature_nodes/core/platform/workflow_execution_metadata.py
+++ b/src/signature_nodes/core/platform/workflow_execution_metadata.py
@@ -1,6 +1,9 @@
 import json
 
+from uuid_extensions import uuid7str
+
 from ...categories import PLATFORM_IO_CAT
+from ...shared import settings
 
 
 class WorkflowExecutionMetadata:
@@ -53,6 +56,8 @@ class WorkflowExecutionMetadata:
 
     def execute(self, json_str: str) -> tuple[str, str, str, str, str, str, str, str]:
         json_dict = json.loads(json_str)
+        settings.correlation_id = json_dict.get("correlation_id", uuid7str())
+
         return (
             json_dict.get("backend_api_host", ""),
             json_dict.get("generate_service_host", ""),

--- a/src/signature_nodes/neurochain/dojo/create_training_run.py
+++ b/src/signature_nodes/neurochain/dojo/create_training_run.py
@@ -3,6 +3,7 @@ from neurochain.dojo.create_training_run import (
 )
 
 from ...categories import DOJO_CAT
+from ...shared import settings
 
 
 class CreateTrainingRun:
@@ -82,4 +83,5 @@ class CreateTrainingRun:
             generate_service_host=generate_service_host,
             backend_cognito_secret_name=backend_cognito_secret_name,
             cover_image_path=cover_image_path,
+            correlation_id=settings.correlation_id,
         )

--- a/src/signature_nodes/neurochain/dojo/start_training_run.py
+++ b/src/signature_nodes/neurochain/dojo/start_training_run.py
@@ -1,6 +1,7 @@
 from neurochain.dojo.start_training_run import StartTrainingRun as StartTrainingRunNeurochain
 
 from ...categories import DOJO_CAT
+from ...shared import settings
 
 
 class StartTrainingRun:
@@ -54,5 +55,6 @@ class StartTrainingRun:
             runpod_endpoint_id,
             backend_api,
             backend_api_secret_name,
+            settings.correlation_id,
         )
         return (return_message,)

--- a/src/signature_nodes/shared.py
+++ b/src/signature_nodes/shared.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+from uuid_extensions import uuid7str
+
 MAX_INT: int = sys.maxsize
 MAX_FLOAT: float = sys.float_info.max
 BASE_COMFY_DIR: str = os.path.dirname(os.path.realpath(__file__)).split("custom_nodes")[0]
@@ -50,3 +52,10 @@ class AnyType(str):
 
 
 any_type = AnyType("*")
+
+
+class GlobalSettings:
+    correlation_id: str = uuid7str()
+
+
+settings = GlobalSettings()


### PR DESCRIPTION
[JIRA Issue](https://signature-ai.atlassian.net/browse/SIGML-763)

## Description
This PR adds a global setting with a correlation ID. The correlation ID will be set by the workflow execution metadata. We also create a default ID, e.g. we can bypass the workflow execution metadata in local development and still have a correlation ID in the logs.

You need the paralllel PR of neurochain to test this.

Example workflow: [training.json](https://github.com/user-attachments/files/19779994/training.json)
